### PR TITLE
fix: fix asynchronous_jobs tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,6 @@ using Snowflurry, SnowflurryPlots
 c = QuantumCircuit(qubit_count=2)
 push!(c, hadamard(1))
 push!(c, control_x(1, 2))
-push!(c, readout(1, 1))
-push!(c, readout(2, 2))
 ψ = simulate(c)
 plot_histogram(c, 100)
 ```

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ using Snowflurry, SnowflurryPlots
 c = QuantumCircuit(qubit_count=2)
 push!(c, hadamard(1))
 push!(c, control_x(1, 2))
+push!(c, readout(1, 1))
+push!(c, readout(2, 2))
 ψ = simulate(c)
 plot_histogram(c, 100)
 ```

--- a/tutorials/asynchronous_jobs.jl
+++ b/tutorials/asynchronous_jobs.jl
@@ -20,12 +20,13 @@ function fibonacci(n)
     if n <= 2
         return 1
     end
+
+    # We need to yield here if we want other tasks to run.
+    yield()
     return fibonacci(n - 1) + fibonacci(n - 2)
 end
 
 fibonacci(30)
-
-yield()
 
 result = fetch(task)
 println(result)

--- a/tutorials/asynchronous_jobs.jl
+++ b/tutorials/asynchronous_jobs.jl
@@ -1,6 +1,6 @@
 using Snowflurry
 
-circuit = QuantumCircuit(qubit_count = 2, instructions = [hadamard(1), control_x(1, 2)])
+circuit = QuantumCircuit(qubit_count = 2, instructions = [hadamard(1), control_x(1, 2), readout(1, 1), readout(2, 2)])
 
 user = ENV["ANYON_QUANTUM_USER"]
 token = ENV["ANYON_QUANTUM_TOKEN"]
@@ -9,10 +9,8 @@ host = ENV["ANYON_QUANTUM_HOST"]
 qpu = AnyonYukonQPU(host = host, user = user, access_token = token)
 
 shot_count = 200
-task = Task(() -> run_job(qpu, circuit, shot_count))
+task = Task(() -> transpile_and_run_job(qpu, circuit, shot_count))
 schedule(task)
-
-yieldto(task)
 
 # Simulate work by calculating the nth Fibonacci number slowly
 function fibonacci(n)
@@ -23,6 +21,8 @@ function fibonacci(n)
 end
 
 fibonacci(30)
+
+yield()
 
 result = fetch(task)
 println(result)

--- a/tutorials/asynchronous_jobs.jl
+++ b/tutorials/asynchronous_jobs.jl
@@ -1,6 +1,9 @@
 using Snowflurry
 
-circuit = QuantumCircuit(qubit_count = 2, instructions = [hadamard(1), control_x(1, 2), readout(1, 1), readout(2, 2)])
+circuit = QuantumCircuit(
+    qubit_count = 2,
+    instructions = [hadamard(1), control_x(1, 2), readout(1, 1), readout(2, 2)],
+)
 
 user = ENV["ANYON_QUANTUM_USER"]
 token = ENV["ANYON_QUANTUM_TOKEN"]


### PR DESCRIPTION
The tutorial now needs explicit `readout` operations.

In my testing, however, I also found that our synchronization wasn't reliable... I took a stab at improving it but we should take a close look at it.