### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Pkg.add(url="https://github.com/SnowflurrySDK/SnowflurryPlots.jl", rev="main")
 
 # Getting Started
 
-The best way to learn Snowflurry is to use it! Let's try to make a two-qubit circuit which implements a [Bell/EPR state](https://en.wikipedia.org/wiki/Bell_state). We'll use Snowflurry to construct and simulate the circuit then verify our construction.
+The best way to learn Snowflurry is to use it! Let's try to make a two-qubit circuit which produces a [Bell/EPR state](https://en.wikipedia.org/wiki/Bell_state). We'll use Snowflurry to construct and simulate the circuit then verify the produced `Ket`.
 
 The quantum circuit for generating a Bell state involves a Hadamard gate on one of the qubits followed by a CNOT gate (see [here](https://en.wikipedia.org/wiki/Quantum_logic_gate) for an introduction to quantum logic gates). This circuit is shown below:
 
@@ -97,7 +97,7 @@ The first line adds a Hadamard gate to circuit object `c` which will operate on 
 
 **Note**: Unlike C++ or Python, indexing in Julia starts from "1" and not "0"!
 
-Once we've built our circuit, we can consider what, if any, transpilations we should apply. Transpilation is the process of rewriting the sequence of operations in a circuit to a new sequence. Typically, the new sequence will yield the same quantum state as the old sequence but could optimize the choice of gates used for performance or portability to different hardware. Since the circuit is relatively small and Snowflurry's simulator can handle all gates, we won't run any transpilation.
+Once we've built our circuit, we can consider if it would benefit from applying any transpilation operations. Transpilation is the process of rewriting the sequence of operations in a circuit to a new sequence. As a rule, the new sequence will yield the same quantum state as the old sequence but possibly optimizing the choice of gates used for performance, using only those gates supported by a specific hardware QPU. Since the circuit is relatively small and Snowflurry's simulator can handle all gates, we won't run any transpilation for the time being.
 
 Next, we'll simulate our circuit to see if we've built what we expect.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ using Snowflurry, SnowflurryPlots
 c = QuantumCircuit(qubit_count=2)
 push!(c, hadamard(1))
 push!(c, control_x(1, 2))
+push!(c, readout(1, 1))
+push!(c, readout(2, 2))
 ψ = simulate(c)
 plot_histogram(c, 100)
 ```

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ push!(c, control_x(1, 2))
 plot_histogram(c, 100)
 ```
 
-To execute a circuit on real hardware, consult [our tutorial](https://snowflurrysdk.github.io/Snowflurry.jl/stable/tutorials/run_circuit_anyon.html).
+You can learn to execute circuits on simulated hardware by following [the Virtual QPU tutorial](https://snowflurrysdk.github.io/Snowflurry.jl/stable/tutorials/run_circuit_virtual.html).
+
+For selected partners and users who have been granted access to Anyon's hardware, follow [the Virtual QPU tutorial](https://snowflurrysdk.github.io/Snowflurry.jl/stable/tutorials/run_circuit_virtual.html) first, then check out how to run circuits [on real hardware](https://snowflurrysdk.github.io/Snowflurry.jl/stable/tutorials/run_circuit_anyon.html).
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The first line adds a Hadamard gate to circuit object `c` which will operate on 
 
 **Note**: Unlike C++ or Python, indexing in Julia starts from "1" and not "0"!
 
-The next step we want to take is to simulate our circuit. We do not need to transpile our circuit since our simulator can handle all gates, but for larger circuit you should consider transpilation to reduce the amount of work the simulator has to perform.
+The next step we want to take is to execute our circuit. Instead of submitting a job to a remote quantum service, we will use Snowflurry's built-in simulator. We do not need to transpile our circuit since our simulator can handle all gates, but for larger circuit you should consider transpilation to reduce the amount of work the simulator has to perform.
 
 ```julia
 ψ = simulate(c)
@@ -146,9 +146,11 @@ push!(c, control_x(1, 2))
 plot_histogram(c, 100)
 ```
 
+To execute a circuit on real hardware, consult [our tutorial](https://snowflurrysdk.github.io/Snowflurry.jl/stable/tutorials/run_circuit_anyon.html).
+
 # Roadmap
 
-See what we have planned by looking at the [Snowflurry Github Project](https://github.com/orgs/SnowflurrySDK/projects/8).
+See what we have planned by looking at the [Snowflurry Github Project](https://github.com/orgs/SnowflurrySDK/projects/1).
 
 # Snowflurry Contributors Community
 

--- a/docs/src/tutorials/anyon_qpu.md
+++ b/docs/src/tutorials/anyon_qpu.md
@@ -10,7 +10,7 @@ DocTestSetup = quote
 end
 ```
 
-In the [previous tutorial](tutorials/virtual_qpu.md), we learnt how to run a quantum circuit on a virtual QPU. We also learnt that every QPU driver should adhere to the `AbstractQPU` API.
+In the [previous tutorial](virtual_qpu.md), we learnt how to run a quantum circuit on a virtual QPU. We also learnt that every QPU driver should adhere to the `AbstractQPU` API.
 
 In this tutorial, we will learn how to submit a job to real hardware. At the moment, we have only implemented the driver for Anyon's quantum processors but we welcome contributions from other members of the community, as well as other hardware vendors to use `Snowflurry` with a variety of machines.
 

--- a/docs/src/tutorials/anyon_qpu.md
+++ b/docs/src/tutorials/anyon_qpu.md
@@ -151,4 +151,4 @@ The results show that the samples are mostly sampled between state $\left|00\rig
 
 
 !!! note
-	The user can skip the explicit transpiling step by using the `transpile_and_run` function. This function will use the default transpiler of the QPU and then submit the job to the machine.
+	The user can skip the explicit transpiling step by using the `transpile_and_run_job` function. This function will use the default transpiler of the QPU and then submit the job to the machine.

--- a/docs/src/tutorials/basics.md
+++ b/docs/src/tutorials/basics.md
@@ -120,4 +120,4 @@ plot_histogram(c, 100)
 ```
 ![Measurement results histogram](../assets/index/index_histogram.png)
 
-In the next tutorial, we will discuss how to run the above circuit on a real quantum processor. 
+In the next tutorial, we will discuss how to run the above circuit on a virtual quantum processor.

--- a/docs/src/tutorials/virtual_qpu.md
+++ b/docs/src/tutorials/virtual_qpu.md
@@ -1,17 +1,17 @@
 # Run a circuit on a Virtual QPU
 
-In the previous tutorial, we introduced some basic concepts of quantum computing, namely the quantum circuit and quantum gates. 
+In the previous tutorial, we introduced some basic concepts of quantum computing, namely the quantum circuit and quantum gates.
 
-We also learnt how to build a quantum circuit using `Snowflurry` and simulate the result of such circuit using our local machine. 
+We also learnt how to build a quantum circuit using `Snowflurry` and simulate the result of such circuit using our local machine.
 
-In this tutorial, we will the steps involved in running a quantum circuit on both a virtual and a real Quantum Processing Unit (QPU). 
+In this tutorial, we will cover the steps involved in running a quantum circuit on a virtual Quantum Processing Unit (QPU).
 
 
 ## QPU Object
-Interactions with different QPUs are facilitated using `struct`s (objects) that represent QPU hardware.  These structures are used to implement a harmonized interface and are derived from an `abstract type` called `AbstractQPU`. This interface gives you a unified way to write code that is agnostic of the quantum service you are using. The interface dictates how to get metadata about the QPU, how to run a quantum circuit on the QPU, and more. 
+Interactions with different QPUs are facilitated using `struct`s (objects) that represent QPU hardware.  These structures are used to implement a harmonized interface and are derived from an `abstract type` called `AbstractQPU`. This interface gives you a unified way to write code that is agnostic of the quantum service you are using. The interface dictates how to get metadata about the QPU, how to run a quantum circuit on the QPU, and more.
 
-!!! warning 
-    You should not use `AbstractQPU`, rather use a QPU object which is derived from `AbstractQPU`. For further details on the implemented derived QPUs, see the [Library page](../library/qpu.md#Quantum-Processing-Unit). 
+!!! warning
+	You should not use `AbstractQPU`, rather use a QPU object which is derived from `AbstractQPU`. For further details on the implemented derived QPUs, see the [Library page](../library/qpu.md#Quantum-Processing-Unit).
 
 Now that you know what QPU objects are, let's get started by importing `Snowflurry`:
 ```jldoctest get_qpu_metadata_tutorial; output = false
@@ -63,8 +63,36 @@ Quantum Circuit Object:
 q[1]:──H────*──
             |  
 q[2]:───────X──
-```               
-We can then run this circuit on the virtual qpu for let's say 101 shots. 
+```
+
+Although we've created a circuit that makes a Bell pair, we need to *meaure*
+something in order to collect any results. In Snowflurry, we can use a
+`readout` instruction to perform a measurement.
+
+```jldoctest get_qpu_metadata_tutorial; output = true
+push!(c,readout(1,1),readout(2,2))
+# output
+Quantum Circuit Object:
+   qubit_count: 2 
+q[1]:──H────*────✲───────
+            |            
+q[2]:───────X─────────✲──
+```
+Here we see that a `readout` instruction can be added to a circuit like any
+other gate. Each readout instruction needs two parameters: which qubit to
+measure and which result bit to write to. For example, `readout(2, 4)` means
+"read qubit 2 and store the result in classical bit 4". So, in this example,
+the first readout reads from qubit 1 and writes that result to bit 1 of the
+result. The second readout does the same for qubit 2 and bit 2 of the result.
+
+In Snowflurry, `readout` instructions can read from any qubit and write to any
+result bit but with some restrictions:
+- Any `readout` operation must be the final operation applied to its target qubit
+  - We plan to lift this restriction in future versions of Snowflurry
+- Separate `readout` operations must write to separate result bits
+
+With our measurements defined, we can now run this circuit on the virtual qpu
+for let's say 100 shots.
 
 ```julia
 shots_count=100
@@ -77,12 +105,14 @@ print(result)
 
 Dict("00" => 53, "11" => 47)
 ```
+Here we see that, after measurement, the classical result bits were set to `00`
+in 53 of the 100 shots. In the other 47 shots, the result bits were set to `11`.
 
 !!! note
-	The reason the number of measured values for states `00` and `11` are not necessarily equal is due to the fact that `VirtualQPU` tries to mimic the statistical nature of real hardware. By increasing the `shots_count` the experiment will confirm that the probability of `00` and `11` are equal. 
+	The reason the number of measured values for states `00` and `11` are not necessarily equal is due to the fact that `VirtualQPU` tries to mimic the statistical nature of real hardware. By increasing the `shots_count` the experiment will confirm that the probability of `00` and `11` are equal.
 
 
 
-The virtual QPU currently mimics an ideal hardware with no error. In future versions, we expect to add noise models for sources such as crosstalk, thermal noise, etc. 
+The virtual QPU currently mimics an ideal hardware with no error. In future versions, we expect to add noise models for sources such as crosstalk, thermal noise, etc.
 
-In the next tutorial, we will show how to submit a job to real quantum processing hardware. 
+In the next tutorial, we will show how to submit a job to real quantum processing hardware.


### PR DESCRIPTION
This change adds some (but not all) of the documentation for explicit readouts. It also updates/fixes a few things that make references amongst our `docs/src/tutorials` make sense.

The important bit is the explanation of `readout` and `measurement` in `docs/src/tutorials/virtual_qpu.md`. Let's make sure we're all happy with the language there as it will be users' first impression of our readouts.