### PR TITLE
feat/inverse of operator

### DIFF
--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -276,6 +276,12 @@ DenseOperator(m::SizedMatrix{N,N,T}) where {N,T<:Real} =
 
 get_matrix(op::DenseOperator{N,T}) where {N,T<:Complex} = convert(Matrix{T}, op.data)
 
+function Base.inv(op::AbstractOperator)::DenseOperator
+    inv_op_matrix = inv(get_matrix(op))
+
+    return DenseOperator(inv_op_matrix)
+end
+
 """
     SwapLikeOperator{N,T<:Complex}<:AbstractOperator
 

--- a/test/test_functions.jl
+++ b/test/test_functions.jl
@@ -196,6 +196,10 @@ function test_operator_implementation(
         @test anticommute(op, op) ≈ result
         @test anticommute(op, DenseOperator(op)) ≈ result
         @test anticommute(DenseOperator(op), (op)) ≈ result
+
+        # Base.inv 
+        invOp = inv(op)
+        @test op * invOp ≈ eye(size(op)[1])
     end
 
     test_label = string(label, " apply_operator")


### PR DESCRIPTION
This allows the call to `inv(op::AbstractOperator)`, and returns the inverse of `op` as a `DenseOperator`. We could further specialize to return a `DiagonalOperator` or `AntiDiagonalOperator` if the inverse presents those features. 