### PR TITLE
docs: remove sidebar sitename

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -35,7 +35,10 @@ println()
 
 makedocs(
     sitename = "Snowflurry",
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "false", sidebar_sitename = false),
+    format = Documenter.HTML(
+        prettyurls = get(ENV, "CI", nothing) == "false",
+        sidebar_sitename = false,
+    ),
     modules = [Snowflurry],
     build = "build",
     pages = [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -35,7 +35,7 @@ println()
 
 makedocs(
     sitename = "Snowflurry",
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "false"),
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "false", sidebar_sitename = false),
     modules = [Snowflurry],
     build = "build",
     pages = [


### PR DESCRIPTION
Since the logo already includes the name Snowflurry, we are duplicating it in the sidebar.

## Before:
![image](https://github.com/SnowflurrySDK/Snowflurry.jl/assets/99685336/de122415-bfca-4d40-a57d-2ff653cc40b4)

## After:
![image](https://github.com/SnowflurrySDK/Snowflurry.jl/assets/99685336/5efee8dc-cea3-480e-a0e8-0e5566b1000f)
