### PR TITLE
fix: add permissions for documenter deploy

### DIFF
--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+          contents: write
+          statuses: write
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
We need to include the permissions that are documented needs in the Deploy Documentation workflow. Otherwise, Documenter won't be able to deploy the documentation.

See [Documenter Documentation: GitHub Actions](https://documenter.juliadocs.org/stable/man/hosting/#GitHub-Actions) for more information.