### PR TITLE
fix: track global phase in operators

### DIFF
--- a/docs/src/library/quantum_toolkit.md
+++ b/docs/src/library/quantum_toolkit.md
@@ -47,4 +47,5 @@ destroy
 number_op
 coherent
 compare_kets
+compare_operators
 ```

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -126,6 +126,7 @@ export
     compare_circuits,
     circuit_contains_gate_type,
     compare_kets,
+    compare_operators,
     permute_qubits!,
     permute_qubits,
     transpile,

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -69,7 +69,7 @@ function get_canonical_global_phase(Ψ::Complex)::Real
 end
 
 function get_canonical_global_phase(ψ::Ket{Complex{T}})::T where {T<:Real}
-    # Use the first non-zero element to determine the global phase of the matrix
+    # Use the first non-zero element to determine the global phase of the ket
     for index in eachindex(ψ.data)
         element = ψ.data[index]
         if (!isapprox(element, 0; atol = sqrt(eps(T))))

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -1791,6 +1791,44 @@ function get_canonical_global_phase(H::AbstractMatrix{Complex{T}})::T where {T<:
     return T(0)
 end
 
+
+"""
+
+    compare_operators(H_0::AbstractOperator,H_1::AbstractOperator)::Bool
+
+Checks for equivalence allowing for a global phase difference between two input operators.
+
+# Examples
+```jldoctest
+julia> H_0 = z_90()
+(2,2)-element Snowflurry.DiagonalOperator:
+Underlying data type: ComplexF64:
+0.7071067811865476 - 0.7071067811865475im    .
+.    0.7071067811865476 + 0.7071067811865475im
+
+
+julia> H_1 = phase_shift(pi/2)
+(2,2)-element Snowflurry.DiagonalOperator:
+Underlying data type: ComplexF64:
+1.0 + 0.0im    .
+.    6.123233995736766e-17 + 1.0im
+
+
+julia> compare_operators(H_0, H_1)
+true
+
+julia> H_1 *= sigma_x()
+(2, 2)-element Snowflurry.DenseOperator:
+Underlying data ComplexF64:
+0.0 + 0.0im    1.0 + 0.0im
+6.123233995736766e-17 + 1.0im    0.0 + 0.0im
+
+
+julia> compare_operators(H_0, H_1) # no longer equivalent after applying sigma x
+false
+
+```
+"""
 function compare_operators(H_0::AbstractOperator, H_1::AbstractOperator)::Bool
     m_0 = get_matrix(H_0)
     m_1 = get_matrix(H_1)

--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -1794,7 +1794,7 @@ end
 
 """
 
-    compare_operators(H_0::AbstractOperator,H_1::AbstractOperator)::Bool
+    compare_operators(H_0::AbstractOperator, H_1::AbstractOperator)::Bool
 
 Checks for equivalence allowing for a global phase difference between two input operators.
 
@@ -1807,7 +1807,7 @@ Underlying data type: ComplexF64:
 .    0.7071067811865476 + 0.7071067811865475im
 
 
-julia> H_1 = phase_shift(pi/2)
+julia> H_1 = phase_shift(pi / 2)
 (2,2)-element Snowflurry.DiagonalOperator:
 Underlying data type: ComplexF64:
 1.0 + 0.0im    .

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -1501,8 +1501,7 @@ y_minus_90(T::Type{<:Complex} = ComplexF64) = rotation(-pi / 2, pi / 2, T)
 """
     z_90()
 
-Return the `Operator` which applies a ``π/2`` rotation about the ``Z`` axis. The unitary of the `R_z\\left(\\frac{\\pi}{2}\\right)` is symmetric.
-
+Return the `Operator` which applies a ``π/2`` rotation about the ``Z`` axis.
 
 The `Operator` is defined as:
 ```math
@@ -1516,8 +1515,7 @@ z_90(T::Type{<:Complex} = ComplexF64) = rotation_z(pi / 2, T)
 """
     z_minus_90()
 
-Return the `Operator` which applies a ``-π/2`` rotation about the ``Z`` axis. The unitary of the `R_z\\left(-\\frac{\\pi}{2}\\right)` is symmetric.
-
+Return the `Operator` which applies a ``-π/2`` rotation about the ``Z`` axis.
 The `Operator` is defined as:
 ```math
 R_z\\left(-\\frac{\\pi}{2}\\right) = \\begin{bmatrix}
@@ -1602,8 +1600,7 @@ phase_shift(phi, T::Type{<:Complex} = ComplexF64) = DiagonalOperator(T[1.0, exp(
 """
     rotation_z(lambda)
 
-Return the `DiagonalOperator` that applies a rotation of `z`. The unitary of the `R_z\\left(\\lambda)` is symmetric.
-
+Return the `DiagonalOperator` that applies a rotation of `z`.
 
 The `DiagonalOperator` is defined as:
 ```math

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -1501,7 +1501,8 @@ y_minus_90(T::Type{<:Complex} = ComplexF64) = rotation(-pi / 2, pi / 2, T)
 """
     z_90()
 
-Return the `Operator` which applies a ``π/2`` rotation about the ``Z`` axis.
+Return the `Operator` which applies a ``π/2`` rotation about the ``Z`` axis. The unitary of the `R_z\\left(\\frac{\\pi}{2}\\right)` is symmetric.
+
 
 The `Operator` is defined as:
 ```math
@@ -1515,7 +1516,7 @@ z_90(T::Type{<:Complex} = ComplexF64) = rotation_z(pi / 2, T)
 """
     z_minus_90()
 
-Return the `Operator` which applies a ``-π/2`` rotation about the ``Z`` axis.
+Return the `Operator` which applies a ``-π/2`` rotation about the ``Z`` axis. The unitary of the `R_z\\left(-\\frac{\\pi}{2}\\right)` is symmetric.
 
 The `Operator` is defined as:
 ```math
@@ -1601,7 +1602,8 @@ phase_shift(phi, T::Type{<:Complex} = ComplexF64) = DiagonalOperator(T[1.0, exp(
 """
     rotation_z(lambda)
 
-Return the `DiagonalOperator` that applies a rotation of `z` .
+Return the `DiagonalOperator` that applies a rotation of `z`. The unitary of the `R_z\\left(\\lambda)` is symmetric.
+
 
 The `DiagonalOperator` is defined as:
 ```math

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -1506,12 +1506,11 @@ Return the `Operator` which applies a ``π/2`` rotation about the ``Z`` axis.
 The `Operator` is defined as:
 ```math
 R_z\\left(\\frac{\\pi}{2}\\right) = \\begin{bmatrix}
-    1 & 0 \\\\
-    0 & i
-    \\end{bmatrix}.
-```
+    e^{-i\\frac{pi}{4} & 0 \\\\[0.5em]
+    0 & e^{i\\frac{pi}{4}}
+\\end{bmatrix}.
 """
-z_90(T::Type{<:Complex} = ComplexF64) = phase_shift(pi / 2, T)
+z_90(T::Type{<:Complex} = ComplexF64) = rotation_z(pi / 2, T)
 
 """
     z_minus_90()
@@ -1521,12 +1520,12 @@ Return the `Operator` which applies a ``-π/2`` rotation about the ``Z`` axis.
 The `Operator` is defined as:
 ```math
 R_z\\left(-\\frac{\\pi}{2}\\right) = \\begin{bmatrix}
-    1 & 0 \\\\
-    0 & -i
-    \\end{bmatrix}.
+    e^{i\\frac{pi}{4} & 0 \\\\[0.5em]
+    0 & e^{-i\\frac{pi}{4}}
+\\end{bmatrix}.
 ```
 """
-z_minus_90(T::Type{<:Complex} = ComplexF64) = phase_shift(-pi / 2, T)
+z_minus_90(T::Type{<:Complex} = ComplexF64) = rotation_z(-pi / 2, T)
 
 """
     rotation(theta, phi)
@@ -1598,6 +1597,26 @@ P(\\phi) = \\begin{bmatrix}
 ```
 """
 phase_shift(phi, T::Type{<:Complex} = ComplexF64) = DiagonalOperator(T[1.0, exp(im * phi)])
+
+"""
+    rotation_z(lambda)
+
+Return the `DiagonalOperator` that applies a rotation of `z` .
+
+The `DiagonalOperator` is defined as:
+```math
+R_z(\\lambda) = \\begin{bmatrix}
+    e^{-i\\frac{\\lambda}{2} & 0 \\\\[0.5em]
+    0 & e^{i\\frac{\\lambda}{2}}
+\\end{bmatrix}.
+```
+"""
+rotation_z(lambda, T::Type{<:Complex} = ComplexF64) = DiagonalOperator(
+    T[
+        exp(-im * lambda / 2.0),
+        exp(im * lambda / 2.0),
+    ]
+)
 
 """
     universal(theta, phi, lambda)

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -1611,12 +1611,8 @@ R_z(\\lambda) = \\begin{bmatrix}
 \\end{bmatrix}.
 ```
 """
-rotation_z(lambda, T::Type{<:Complex} = ComplexF64) = DiagonalOperator(
-    T[
-        exp(-im * lambda / 2.0),
-        exp(im * lambda / 2.0),
-    ]
-)
+rotation_z(lambda, T::Type{<:Complex} = ComplexF64) =
+    DiagonalOperator(T[exp(-im * lambda / 2.0), exp(im * lambda / 2.0)])
 
 """
     universal(theta, phi, lambda)

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -99,7 +99,7 @@ function as_universal_gate(target::Integer, op::AbstractOperator)::Gate{Universa
     matrix = get_matrix(op)
 
     #find global phase offset angle
-    alpha = atan(imag(matrix[1, 1]), real(matrix[1, 1]))
+    alpha = get_canonical_global_phase(matrix)
 
     #remove global offset
     matrix *= exp(-im * alpha)

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -824,11 +824,11 @@ q[2]:─────
 
 julia> transpiled_circuit = transpile(transpiler, circuit)
 Quantum Circuit Object:
-   qubit_count: 2 
-   bit_count: 2 
-q[1]:──Z_90────X_90────Z────X_m90────Z_90──
-                                           
-q[2]:──────────────────────────────────────
+   qubit_count: 2
+   bit_count: 2
+q[1]:──X_90────Z────X_m90──
+
+q[2]:──────────────────────
                                            
 
 

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -310,9 +310,9 @@ end
     @test get_instruction_symbol(get_gate_symbol(z90)) == "z_90"
     @test get_symbol_for_instruction("z_90") == Snowflurry.Z90
     @test get_display_symbols(get_gate_symbol(z90)) == ["Z_90"]
-    @test get_matrix(get_operator(get_gate_symbol(z90))) ≈ [
-        1 0
-        0 im
+    @test get_matrix(get_operator(get_gate_symbol(z90))) ≈ (1 / sqrt(2.0)) * [
+        1-im 0
+        0 1+im
     ]
     @test isequal(z90, z_90(1))
     @test !isequal(z90, z_90(2))
@@ -321,9 +321,9 @@ end
     @test get_instruction_symbol(get_gate_symbol(zm90)) == "z_minus_90"
     @test get_symbol_for_instruction("z_minus_90") == Snowflurry.ZM90
     @test get_display_symbols(get_gate_symbol(zm90)) == ["Z_m90"]
-    @test get_matrix(get_operator(get_gate_symbol(zm90))) ≈ [
-        1 0
-        0 -im
+    @test get_matrix(get_operator(get_gate_symbol(zm90))) ≈ (1 / sqrt(2.0)) * [
+        1+im 0
+        0 1-im
     ]
     @test isequal(zm90, z_minus_90(1))
     @test !isequal(zm90, z_minus_90(2))

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -321,3 +321,11 @@ end
         hspace_size_per_body,
     )
 end
+
+@testset "get_canonical_global_phase" begin
+    ψ_0 = Ket([0.0, 0.0, 0.0, 0.0])
+    @test 0 == Snowflurry.get_canonical_global_phase(ψ_0)
+
+    m_0 = Complex.([0.0 0.0; 0.0 0.0])
+    @test 0 == Snowflurry.get_canonical_global_phase(m_0)
+end

--- a/test/qobj.jl
+++ b/test/qobj.jl
@@ -323,9 +323,19 @@ end
 end
 
 @testset "get_canonical_global_phase" begin
-    ψ_0 = Ket([0.0, 0.0, 0.0, 0.0])
-    @test 0 == Snowflurry.get_canonical_global_phase(ψ_0)
+    function run_ket_test(ψ::Ket, expected_global_phase::Real)
+        @test expected_global_phase ≈ Snowflurry.get_canonical_global_phase(ψ)
+    end
 
-    m_0 = Complex.([0.0 0.0; 0.0 0.0])
-    @test 0 == Snowflurry.get_canonical_global_phase(m_0)
+    run_ket_test(Ket([0.0, 0.0, 0.0, 0.0]), 0)
+    run_ket_test(Ket([exp(im * pi / 2), 0.0, 0.0, 0.0]), pi / 2)
+    run_ket_test(Ket([0.0, exp(im * pi / 3), 0.0, 0.0]), pi / 3)
+
+    function run_matrix_test(m::AbstractMatrix, expected_global_phase::Real)
+        @test expected_global_phase ≈ Snowflurry.get_canonical_global_phase(m)
+    end
+
+    run_matrix_test(Complex.([0.0 0.0; 0.0 0.0]), 0)
+    run_matrix_test(Complex.([exp(im * pi / 4) 0.0; 0.0 0.0]), pi / 4)
+    run_matrix_test(Complex.([0.0 exp(im * pi / 5); 0.0 0.0]), pi / 5)
 end

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -67,8 +67,11 @@ test_instructions = [
     for instr in single_qubit_instructions
         universal_equivalent =
             Snowflurry.as_universal_gate(target, get_operator(get_gate_symbol(instr)))
-        @test get_operator(get_gate_symbol(instr)) ≈
-              get_operator(get_gate_symbol(universal_equivalent))
+
+        @test Snowflurry.compare_operators(
+            get_operator(get_gate_symbol(instr)),
+            get_operator(get_gate_symbol(universal_equivalent)),
+        )
     end
 end
 


### PR DESCRIPTION
This ensures that the global phase is correctly taken into account in pre-defined operators.

Since it's required to make things work, this also updates `compare_kets` to correctly handle the global phase if the first element is zero and adds `compare_operators`.

This is required for #358, but it does not yet ensure that the transpilation 