### PR TITLE
Feat/subset of lattice

### DIFF
--- a/docs/src/tutorials/anyon_qpu.md
+++ b/docs/src/tutorials/anyon_qpu.md
@@ -124,7 +124,7 @@ SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoN
 1──2──3──4──5──6
 ), CastSwapToCZGateTranspiler(), CompressSingleQubitGatesTranspiler(), SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler(), RejectNonNativeInstructionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
-, 6)])
+)])
 ```
 
 Next, let's transpile the original circuit:

--- a/docs/src/tutorials/anyon_qpu.md
+++ b/docs/src/tutorials/anyon_qpu.md
@@ -65,7 +65,7 @@ get_metadata(qpu)
 
 # output
 
-Dict{String, Union{Int64, String}} with 7 entries:
+Dict{String, Union{Int64, String, Vector{Int64}}} with 7 entries:
   "qubit_count"       => 6
   "generation"        => "Yukon"
   "manufacturer"      => "Anyon Systems Inc."
@@ -122,7 +122,9 @@ transpiler = get_transpiler(qpu)
 # output
 SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoNotConflictTranspiler(), UnsupportedGatesTranspiler(), DecomposeSingleTargetSingleControlGatesTranspiler(), CastToffoliToCXGateTranspiler(), CastCXToCZGateTranspiler(), CastISwapToCZGateTranspiler(), SwapQubitsForAdjacencyTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
-), CastSwapToCZGateTranspiler(), CompressSingleQubitGatesTranspiler(), SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler()])
+), CastSwapToCZGateTranspiler(), CompressSingleQubitGatesTranspiler(), SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler(), RejectNonNativeInstructionsTranspiler(LineConnectivity{6}
+1──2──3──4──5──6
+, 6)])
 ```
 
 Next, let's transpile the original circuit:

--- a/docs/src/tutorials/virtual_qpu.md
+++ b/docs/src/tutorials/virtual_qpu.md
@@ -45,7 +45,7 @@ or alternatively, retrieve the QPU metadata in a `Dict{String,String}` format th
 ```jldoctest get_qpu_metadata_tutorial; output = true
 get_metadata(qpu_v)
 # output
-Dict{String, String} with 2 entries:
+Dict{String, Union{Int64, String, Vector{Int64}}} with 2 entries:
   "developers" => "Anyon Systems Inc."
   "package"    => "Snowflurry.jl"
 

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -77,6 +77,7 @@ export
     CircuitContainsAReadoutTranspiler,
     UnsupportedGatesTranspiler,
     DecomposeSingleTargetSingleControlGatesTranspiler,
+    RejectNonNativeInstructionsTranspiler,
 
     # Functions
     controlled,
@@ -238,7 +239,7 @@ using PrecompileTools
         toffoli(1, 2, 6),
         swap(2, 5),
         iswap(4, 1),
-        iswap_dagger(6, 3),
+        # iswap_dagger(6, 3),
         controlled(hadamard(1), [2]),
     ]
 
@@ -259,6 +260,7 @@ using PrecompileTools
         CompressRzGatesTranspiler(),
         SimplifyRzGatesTranspiler(),
         ReadoutsAreFinalInstructionsTranspiler(),
+        RejectNonNativeInstructionsTranspiler(AnyonYukonConnectivity, 6),
     ])
 
     for gate in gates_list

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -47,6 +47,7 @@ export
     AnyonYukonQPU,
     AnyonYamaskaQPU,
     VirtualQPU,
+    Metadata,
     Client,
     Status,
     NotImplementedError,

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -70,7 +70,6 @@ export
     SimplifyRzGatesTranspiler,
     SimplifyTrivialGatesTranspiler,
     CompressRzGatesTranspiler,
-    TrivialTranspiler,
     RemoveSwapBySwappingGatesTranspiler,
     ReadoutsAreFinalInstructionsTranspiler,
     ReadoutsDoNotConflictTranspiler,

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -259,7 +259,7 @@ using PrecompileTools
         CompressRzGatesTranspiler(),
         SimplifyRzGatesTranspiler(),
         ReadoutsAreFinalInstructionsTranspiler(),
-        RejectNonNativeInstructionsTranspiler(AnyonYukonConnectivity, 6),
+        RejectNonNativeInstructionsTranspiler(AnyonYukonConnectivity),
     ])
 
     for gate in gates_list

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -238,7 +238,7 @@ using PrecompileTools
         toffoli(1, 2, 6),
         swap(2, 5),
         iswap(4, 1),
-        # iswap_dagger(6, 3),
+        # iswap_dagger(6, 3), # TODO left out until missing transpiler is added: https://github.com/SnowflurrySDK/Snowflurry.jl/issues/377
         controlled(hadamard(1), [2]),
     ]
 

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -141,6 +141,7 @@ export
     print_connectivity,
     get_connectivity,
     get_connectivity_label,
+    get_excluded_positions,
     get_adjacency_list,
     path_search,
     get_host,

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -277,11 +277,7 @@ julia> get_qubits_distance(3, 24, connectivity)
 ```
 
 """
-function get_qubits_distance(
-    target_1::Int,
-    target_2::Int,
-    c::LineConnectivity,
-)::Real
+function get_qubits_distance(target_1::Int, target_2::Int, c::LineConnectivity)::Real
     for e in c.excluded_positions
         if target_1 ≤ e ≤ target_2
             return NaN

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -474,7 +474,7 @@ SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoN
 1──2──3──4──5──6
 ), CastSwapToCZGateTranspiler(), CompressSingleQubitGatesTranspiler(), SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler(), RejectNonNativeInstructionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
-, 6)])
+)])
 ```
 """
 function get_transpiler(
@@ -500,6 +500,6 @@ function get_transpiler(
         CompressRzGatesTranspiler(),
         SimplifyRzGatesTranspiler(atol),
         ReadoutsAreFinalInstructionsTranspiler(),
-        RejectNonNativeInstructionsTranspiler(connectivity, get_num_qubits(qpu)),
+        RejectNonNativeInstructionsTranspiler(connectivity),
     ])
 end

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -474,8 +474,10 @@ SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoN
 )])
 ```
 """
-function get_transpiler(
-    qpu::UnionAnyonQPU;
+get_transpiler(qpu::UnionAnyonQPU; atol = 1e-6)::Transpiler =
+    get_anyon_transpiler(atol = atol, connectivity = get_connectivity(qpu))
+
+function get_anyon_transpiler(;
     atol = 1e-6,
     connectivity = get_connectivity(qpu),
 )::Transpiler

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -458,7 +458,9 @@ julia> qpu = AnyonYukonQPU(client, "project_id");
 julia> get_transpiler(qpu)
 SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoNotConflictTranspiler(), UnsupportedGatesTranspiler(), DecomposeSingleTargetSingleControlGatesTranspiler(), CastToffoliToCXGateTranspiler(), CastCXToCZGateTranspiler(), CastISwapToCZGateTranspiler(), SwapQubitsForAdjacencyTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
-), CastSwapToCZGateTranspiler(), CompressSingleQubitGatesTranspiler(), SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler()])
+), CastSwapToCZGateTranspiler(), CompressSingleQubitGatesTranspiler(), SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler(), RejectNonNativeInstructionsTranspiler(LineConnectivity{6}
+1──2──3──4──5──6
+, 6)])
 ```
 """
 function get_transpiler(

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -215,7 +215,6 @@ function get_metadata(client::Client, qpu::UnionAnyonQPU)::Metadata
     if qpu isa AnyonYamaskaQPU
         generation = "Yamaska"
         serial_number = "ANYK202301"
-        excluded_positions = collect(7:12)
     end
 
     output = Metadata(

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -164,7 +164,7 @@ get_excluded_positions(qpu::UnionAnyonQPU) = get_excluded_positions(get_connecti
 
 function get_metadata(qpu::UnionAnyonQPU)::Metadata
     if isempty(qpu.metadata)
-        for (k,v) in get_metadata(qpu.client, qpu)
+        for (k, v) in get_metadata(qpu.client, qpu)
             qpu.metadata[k] = v
         end
     end

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -281,7 +281,7 @@ julia> get_qubits_distance(3, 24, connectivity)
 function get_qubits_distance(target_1::Int, target_2::Int, c::LineConnectivity)::Real
     for e in c.excluded_positions
         if target_1 ≤ e ≤ target_2
-            return NaN
+            return Inf
         end
     end
 
@@ -297,7 +297,7 @@ function get_qubits_distance(
     path = path_search(target_1, target_2, connectivity)
 
     if isempty(path)
-        return NaN
+        return Inf
     end
 
     # Manhattan distance

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -34,7 +34,7 @@ struct AnyonYukonQPU <: AbstractQPU
     status_request_throttle::Function
     connectivity::LineConnectivity
     project_id::String
-    metadata::Vector{Metadata}
+    metadata::Metadata
 
     function AnyonYukonQPU(
         client::Client,
@@ -44,7 +44,7 @@ struct AnyonYukonQPU <: AbstractQPU
         if project_id == ""
             throw(ArgumentError(error_msg_empty_project_id))
         end
-        new(client, status_request_throttle, AnyonYukonConnectivity, project_id, Metadata[])
+        new(client, status_request_throttle, AnyonYukonConnectivity, project_id, Metadata())
     end
 
     function AnyonYukonQPU(;
@@ -63,7 +63,7 @@ struct AnyonYukonQPU <: AbstractQPU
             status_request_throttle,
             AnyonYukonConnectivity,
             project_id,
-            Metadata[],
+            Metadata(),
         )
     end
 end
@@ -97,7 +97,7 @@ struct AnyonYamaskaQPU <: AbstractQPU
     status_request_throttle::Function
     connectivity::LatticeConnectivity
     project_id::String
-    metadata::Vector{Metadata}
+    metadata::Metadata
 
     function AnyonYamaskaQPU(
         client::Client,
@@ -112,7 +112,7 @@ struct AnyonYamaskaQPU <: AbstractQPU
             status_request_throttle,
             AnyonYamaskaConnectivity,
             project_id,
-            Metadata[],
+            Metadata(),
         )
     end
     function AnyonYamaskaQPU(;
@@ -132,7 +132,7 @@ struct AnyonYamaskaQPU <: AbstractQPU
             status_request_throttle,
             AnyonYamaskaConnectivity,
             project_id,
-            Metadata[],
+            Metadata(),
         )
     end
 end
@@ -163,10 +163,12 @@ print_connectivity(qpu::AbstractQPU, io::IO = stdout) =
 get_excluded_positions(qpu::UnionAnyonQPU) = get_excluded_positions(get_connectivity(qpu))
 
 function get_metadata(qpu::UnionAnyonQPU)::Metadata
-    if length(qpu.metadata) == 0
-        push!(qpu.metadata, get_metadata(qpu.client, qpu))
+    if isempty(qpu.metadata)
+        for (k,v) in get_metadata(qpu.client, qpu)
+            qpu.metadata[k] = v
+        end
     end
-    return qpu.metadata[1]
+    return qpu.metadata
 end
 
 function Base.show(io::IO, qpu::UnionAnyonQPU)

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -233,10 +233,6 @@ function get_metadata(client::Client, qpu::UnionAnyonQPU)::Metadata
         output["realm"] = realm
     end
 
-    if !isempty(excluded_positions)
-        output["excluded_positions"] = excluded_positions
-    end
-
     return output
 end
 

--- a/src/anyon/qpu_interface.jl
+++ b/src/anyon/qpu_interface.jl
@@ -374,11 +374,8 @@ abstract type AbstractQPU end
 
 get_metadata(qpu::AbstractQPU) = throw(NotImplementedError(:get_metadata, qpu))
 
-is_native_instruction(qpu::AbstractQPU, ::AbstractInstruction) =
-    throw(NotImplementedError(:is_native_instruction, qpu))
-
-is_native_circuit(qpu::AbstractQPU, ::QuantumCircuit) =
-    throw(NotImplementedError(:is_native_circuit, qpu))
+is_native_instruction(::AbstractInstruction, c::AbstractConnectivity) =
+    throw(NotImplementedError(:is_native_instruction, c))
 
 get_transpiler(qpu::AbstractQPU) = throw(NotImplementedError(:get_transpiler, qpu))
 
@@ -405,11 +402,9 @@ Quantum Simulator:
 struct VirtualQPU <: AbstractQPU end
 
 get_metadata(qpu::VirtualQPU) =
-    Dict{String,String}("developers" => "Anyon Systems Inc.", "package" => "Snowflurry.jl")
+    Metadata("developers" => "Anyon Systems Inc.", "package" => "Snowflurry.jl")
 
-is_native_instruction(::VirtualQPU, ::AbstractInstruction)::Bool = true
-
-is_native_circuit(::VirtualQPU, ::QuantumCircuit)::Tuple{Bool,String} = (true, "")
+is_native_instruction(::AbstractInstruction, ::AllToAllConnectivity)::Bool = true
 
 get_transpiler(::VirtualQPU) = SequentialTranspiler([
     CircuitContainsAReadoutTranspiler(),
@@ -475,10 +470,6 @@ function transpile_and_run_job(
 )::Dict{String,Int}
 
     transpiled_circuit = transpile(transpiler, circuit)
-
-    (passed, message) = is_native_circuit(qpu, transpiled_circuit)
-
-    @assert passed "All circuits should be native on VirtualQPU"
 
     return run_job(qpu, transpiled_circuit, shot_count)
 end

--- a/src/anyon/qpu_interface.jl
+++ b/src/anyon/qpu_interface.jl
@@ -404,8 +404,6 @@ struct VirtualQPU <: AbstractQPU end
 get_metadata(qpu::VirtualQPU) =
     Metadata("developers" => "Anyon Systems Inc.", "package" => "Snowflurry.jl")
 
-is_native_instruction(::AbstractInstruction, ::AllToAllConnectivity)::Bool = true
-
 get_transpiler(::VirtualQPU) = SequentialTranspiler([
     CircuitContainsAReadoutTranspiler(),
     ReadoutsDoNotConflictTranspiler(),

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2313,7 +2313,7 @@ function transpile(
     return output
 end
 
-struct RejectNonNativeInstructionsTranspiler <: Transpiler 
+struct RejectNonNativeInstructionsTranspiler <: Transpiler
     connectivity::AbstractConnectivity
     num_qubits::Int
 end
@@ -2323,7 +2323,8 @@ function transpile(
     circuit::QuantumCircuit,
 )::QuantumCircuit
 
-    (passed, message) = is_native_circuit(transpiler.num_qubits, circuit, transpiler.connectivity)
+    (passed, message) =
+        is_native_circuit(transpiler.num_qubits, circuit, transpiler.connectivity)
 
     if !passed
         throw(DomainError(transpiler.connectivity, message))

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -1692,10 +1692,6 @@ function transpile(::CompressRzGatesTranspiler, circuit::QuantumCircuit)::Quantu
     )
 end
 
-struct TrivialTranspiler <: Transpiler end
-
-transpile(::TrivialTranspiler, circuit::QuantumCircuit)::QuantumCircuit = circuit
-
 struct RemoveSwapBySwappingGatesTranspiler <: Transpiler end
 
 """

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2315,7 +2315,6 @@ end
 
 struct RejectNonNativeInstructionsTranspiler <: Transpiler
     connectivity::AbstractConnectivity
-    num_qubits::Int
 end
 
 function transpile(
@@ -2324,7 +2323,7 @@ function transpile(
 )::QuantumCircuit
 
     (passed, message) =
-        is_native_circuit(transpiler.num_qubits, circuit, transpiler.connectivity)
+        is_native_circuit(get_num_qubits(transpiler.connectivity), circuit, transpiler.connectivity)
 
     if !passed
         throw(DomainError(transpiler.connectivity, message))

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2316,3 +2316,22 @@ function transpile(
 
     return output
 end
+
+struct RejectNonNativeInstructionsTranspiler <: Transpiler 
+    connectivity::AbstractConnectivity
+    num_qubits::Int
+end
+
+function transpile(
+    transpiler::RejectNonNativeInstructionsTranspiler,
+    circuit::QuantumCircuit,
+)::QuantumCircuit
+
+    (passed, message) = is_native_circuit(transpiler.num_qubits, circuit, transpiler.connectivity)
+
+    if !passed
+        throw(DomainError(transpiler.connectivity, message))
+    end
+
+    return circuit
+end

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2322,8 +2322,11 @@ function transpile(
     circuit::QuantumCircuit,
 )::QuantumCircuit
 
-    (passed, message) =
-        is_native_circuit(get_num_qubits(transpiler.connectivity), circuit, transpiler.connectivity)
+    (passed, message) = is_native_circuit(
+        get_num_qubits(transpiler.connectivity),
+        circuit,
+        transpiler.connectivity,
+    )
 
     if !passed
         throw(DomainError(transpiler.connectivity, message))

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -618,6 +618,7 @@ end
         "project_id" => expected_project_id,
         "qubit_count" => 12,
         "connectivity_type" => Snowflurry.lattice_connectivity_label,
+        "excluded_positions" => collect(7:12),
     )
 
     qpu = AnyonYamaskaQPU(
@@ -639,6 +640,7 @@ end
         "qubit_count" => 12,
         "connectivity_type" => Snowflurry.lattice_connectivity_label,
         "realm" => expected_realm,
+        "excluded_positions" => collect(7:12),
     )
 
 end

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -534,7 +534,7 @@ end
     @test get_connectivity_label(get_connectivity(qpu)) ==
           Snowflurry.line_connectivity_label
 
-    @test get_metadata(qpu) == Dict{String,Union{String,Int}}(
+    @test get_metadata(qpu) == Metadata(
         "manufacturer" => "Anyon Systems Inc.",
         "generation" => "Yukon",
         "serial_number" => "ANYK202201",
@@ -554,7 +554,7 @@ end
 
     @test Snowflurry.get_realm(qpu) == expected_realm
 
-    @test get_metadata(qpu) == Dict{String,Union{String,Int}}(
+    @test get_metadata(qpu) == Metadata(
         "manufacturer" => "Anyon Systems Inc.",
         "generation" => "Yukon",
         "serial_number" => "ANYK202201",
@@ -611,7 +611,7 @@ end
 
     @test get_connectivity_label(connectivity) == Snowflurry.lattice_connectivity_label
 
-    @test get_metadata(qpu) == Dict{String,Union{String,Int}}(
+    @test get_metadata(qpu) == Metadata(
         "manufacturer" => "Anyon Systems Inc.",
         "generation" => "Yamaska",
         "serial_number" => "ANYK202301",
@@ -631,7 +631,7 @@ end
 
     @test Snowflurry.get_realm(qpu) == expected_realm
 
-    @test get_metadata(qpu) == Dict{String,Union{String,Int}}(
+    @test get_metadata(qpu) == Metadata(
         "manufacturer" => "Anyon Systems Inc.",
         "generation" => "Yamaska",
         "serial_number" => "ANYK202301",

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -489,7 +489,7 @@ end
         [2, 2],
     )
 
-    @test ismissing(get_qubits_distance(1, 12, connectivity))
+    @test isnan(get_qubits_distance(1, 12, connectivity))
 
     io = IOBuffer()
 
@@ -593,7 +593,7 @@ end
 
     connectivity = LatticeConnectivity(6, 4, excluded_positions)
 
-    @test ismissing(get_qubits_distance(1, 9, connectivity))
+    @test isnan(get_qubits_distance(1, 9, connectivity))
 end
 
 @testset "is_native_instruction: NotImplemented" begin
@@ -1166,7 +1166,7 @@ end
             qubit_count = get_num_qubits(qpu) - 1,
             instructions = [toffoli(1, 2, 3), readout(1, 1)],
         )
-        
+
         # using default transpiler with full connectivity
         requestor = MockRequestor(make_request_checker(), post_checker_toffoli)
         test_client = Client(

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -1207,7 +1207,7 @@ end
             qpu,
             circuit,
             shot_count;
-            transpiler = get_transpiler(qpu; connectivity = connectivity),
+            transpiler = Snowflurry.get_anyon_transpiler(connectivity = connectivity),
         )
 
         @test histogram == Dict("001" => shot_count)
@@ -1233,7 +1233,7 @@ end
             qpu,
             circuit,
             shot_count;
-            transpiler = get_transpiler(qpu; connectivity = connectivity),
+            transpiler = Snowflurry.get_anyon_transpiler(connectivity = connectivity),
         ) # no error thrown
     end
 end

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -779,9 +779,11 @@ end
 
     connectivity = get_connectivity(qpu)
 
+    expected_excluded_positions = []
+
     @test get_excluded_positions(qpu) ==
           get_excluded_positions(connectivity) ==
-          collect(7:12)
+          expected_excluded_positions
 
     @test client.host == expected_host
     @test client.user == expected_user
@@ -822,7 +824,6 @@ end
         "project_id" => expected_project_id,
         "qubit_count" => 12,
         "connectivity_type" => Snowflurry.lattice_connectivity_label,
-        "excluded_positions" => collect(7:12),
     )
 
     qpu = AnyonYamaskaQPU(
@@ -844,7 +845,6 @@ end
         "qubit_count" => 12,
         "connectivity_type" => Snowflurry.lattice_connectivity_label,
         "realm" => expected_realm,
-        "excluded_positions" => collect(7:12),
     )
 
 end

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -489,7 +489,7 @@ end
         [2, 2],
     )
 
-    @test isnan(get_qubits_distance(1, 12, connectivity))
+    @test isinf(get_qubits_distance(1, 12, connectivity))
 
     io = IOBuffer()
 
@@ -593,7 +593,7 @@ end
 
     connectivity = LatticeConnectivity(6, 4, excluded_positions)
 
-    @test isnan(get_qubits_distance(1, 9, connectivity))
+    @test isinf(get_qubits_distance(1, 9, connectivity))
 end
 
 @testset "is_native_instruction: NotImplemented" begin

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -701,8 +701,6 @@ end
     )
     client = get_client(qpu)
 
-    @test get_excluded_positions(qpu) == []
-
     io = IOBuffer()
     println(io, qpu)
     @test String(take!(io)) ==
@@ -725,6 +723,22 @@ end
 
     connectivity = get_connectivity(qpu)
 
+    expected_excluded_positions = []
+
+    @test get_excluded_positions(qpu) ==
+          get_excluded_positions(connectivity) ==
+          expected_excluded_positions
+
+    expected_excluded_positions = collect(3:6)
+
+    # simulate a change in metadata from a host server response
+    qpu.metadata["excluded_positions"] = expected_excluded_positions
+
+    @test get_excluded_positions(qpu) ==
+    get_excluded_positions(get_connectivity(qpu)) ==
+    expected_excluded_positions
+
+
     @test client.host == expected_host
     @test client.user == expected_user
     @test client.access_token == expected_access_token
@@ -741,6 +755,7 @@ end
         "project_id" => expected_project_id,
         "qubit_count" => 6,
         "connectivity_type" => Snowflurry.line_connectivity_label,
+        "excluded_positions" => expected_excluded_positions,
     )
 
     qpu = AnyonYukonQPU(
@@ -785,6 +800,15 @@ end
           get_excluded_positions(connectivity) ==
           expected_excluded_positions
 
+    expected_excluded_positions = collect(7:12)
+
+    # simulate a change in metadata from a host server response
+    qpu.metadata["excluded_positions"] = expected_excluded_positions
+
+    @test get_excluded_positions(qpu) ==
+    get_excluded_positions(get_connectivity(qpu)) ==
+    expected_excluded_positions
+
     @test client.host == expected_host
     @test client.user == expected_user
     @test client.access_token == expected_access_token
@@ -824,6 +848,7 @@ end
         "project_id" => expected_project_id,
         "qubit_count" => 12,
         "connectivity_type" => Snowflurry.lattice_connectivity_label,
+        "excluded_positions" => collect(7:12),
     )
 
     qpu = AnyonYamaskaQPU(

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -735,8 +735,8 @@ end
     qpu.metadata["excluded_positions"] = expected_excluded_positions
 
     @test get_excluded_positions(qpu) ==
-    get_excluded_positions(get_connectivity(qpu)) ==
-    expected_excluded_positions
+          get_excluded_positions(get_connectivity(qpu)) ==
+          expected_excluded_positions
 
 
     @test client.host == expected_host
@@ -806,8 +806,8 @@ end
     qpu.metadata["excluded_positions"] = expected_excluded_positions
 
     @test get_excluded_positions(qpu) ==
-    get_excluded_positions(get_connectivity(qpu)) ==
-    expected_excluded_positions
+          get_excluded_positions(get_connectivity(qpu)) ==
+          expected_excluded_positions
 
     @test client.host == expected_host
     @test client.user == expected_user

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -60,7 +60,7 @@ test_instructions = [
         toffoli(1, 4, 3),
         swap(2, 4),
         iswap(4, 1),
-        # iswap_dagger(1, 3),
+        # iswap_dagger(1, 3), # TODO left out until missing transpiler is added: https://github.com/SnowflurrySDK/Snowflurry.jl/issues/377
     ],
 ]
 

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -1686,7 +1686,7 @@ end
         CompressRzGatesTranspiler(),
         SimplifyRzGatesTranspiler(),
         ReadoutsAreFinalInstructionsTranspiler(),
-        RejectNonNativeInstructionsTranspiler(LineConnectivity(42), 42),
+        RejectNonNativeInstructionsTranspiler(LineConnectivity(42)),
     ]
 
     for transpiler in transpilers
@@ -1709,7 +1709,7 @@ end
     ]
 
     for (connectivity, targets) in connectivities_and_targets
-        transpiler = RejectNonNativeInstructionsTranspiler(connectivity, 12)
+        transpiler = RejectNonNativeInstructionsTranspiler(connectivity)
 
         for instr in vcat(single_qubit_instructions, readout(1, 1))
             circuit =

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -795,25 +795,30 @@ end
     end
 end
 
-@testset "AnyonQPUs: SwapQubitsForAdjacencyTranspiler" begin
-    qpus = [
-        AnyonYukonQPU(;
-            host = expected_host,
-            user = expected_user,
-            access_token = expected_access_token,
-            project_id = expected_project_id,
-        ),
-        AnyonYamaskaQPU(;
-            host = expected_host,
-            user = expected_user,
-            access_token = expected_access_token,
-            project_id = expected_project_id,
-        ),
+@testset "AnyonQPUs: SwapQubitsForAdjacencyTranspiler: full connectivity" begin
+    qpus_and_connectivities = [
+        (
+            AnyonYukonQPU(;
+                host = expected_host,
+                user = expected_user,
+                access_token = expected_access_token,
+                project_id = expected_project_id,
+            ),
+            Snowflurry.AnyonYukonConnectivity,
+        )
+        (
+            AnyonYamaskaQPU(;
+                host = expected_host,
+                user = expected_user,
+                access_token = expected_access_token,
+                project_id = expected_project_id,
+            ),
+            Snowflurry.AnyonYamaskaConnectivity,
+        )
     ]
 
-    for qpu in qpus
-        transpiler = get_transpiler(qpu)
-        connectivity = get_connectivity(qpu)
+    for (qpu, connectivity) in qpus_and_connectivities
+        transpiler = get_transpiler(qpu; connectivity = connectivity)
         qubit_count = get_num_qubits(qpu)
 
         for t_0 ∈ 1:qubit_count

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -1742,7 +1742,7 @@ end
     ]
 
     for connectivity in connectivities
-        for target in 1:12
+        for target = 1:12
             input_gates_on_excluded_targets = [
                 phase_shift(target, pi / 3),
                 pi_8(target),
@@ -1761,13 +1761,14 @@ end
 
             for instr in input_gates_on_excluded_targets
                 # instr is native iif it targets non-excluded positions
-                @test !is_native_instruction(instr, connectivity) == (target in excluded_positions)
+                @test !is_native_instruction(instr, connectivity) ==
+                      (target in excluded_positions)
             end
         end
 
-        for control in 1:20
-            for target in 1:20
-                if target == control 
+        for control = 1:20
+            for target = 1:20
+                if target == control
                     continue
                 end
 
@@ -1775,13 +1776,12 @@ end
 
                 # instr is native if it is connected to adjacent qubits on 
                 # non-excluded positions, and it doesnt reach across the blocked region
-                @test is_native_instruction(instr, connectivity) ==  
-                    (
-                        (get_qubits_distance(target, control, connectivity) == 1) &&
-                        !(target in excluded_positions) && 
-                        !(control in excluded_positions) &&
-                        ((control < 9 && target < 9) || (control > 12 && target > 12))
-                    )
+                @test is_native_instruction(instr, connectivity) == (
+                    (get_qubits_distance(target, control, connectivity) == 1) &&
+                    !(target in excluded_positions) &&
+                    !(control in excluded_positions) &&
+                    ((control < 9 && target < 9) || (control > 12 && target > 12))
+                )
             end
         end
     end

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -861,13 +861,14 @@ end
                 access_token = expected_access_token,
                 project_id = expected_project_id,
             ),
-            Snowflurry.AnyonYamaskaConnectivity,
+            # testing with LatticeConnectivity(6,4) induces massive demand on simulate(), with 24-qubit Kets
+            Snowflurry.LatticeConnectivity(3, 4),
         )
     ]
 
     for (qpu, connectivity) in qpus_and_connectivities
         transpiler = get_transpiler(qpu; connectivity = connectivity)
-        qubit_count = get_num_qubits(qpu)
+        qubit_count = get_num_qubits(connectivity)
 
         for t_0 ∈ 1:qubit_count
             for t_1 ∈ 1:qubit_count

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -867,7 +867,7 @@ end
     ]
 
     for (qpu, connectivity) in qpus_and_connectivities
-        transpiler = get_transpiler(qpu; connectivity = connectivity)
+        transpiler = Snowflurry.get_anyon_transpiler(connectivity = connectivity)
         qubit_count = get_num_qubits(connectivity)
 
         for t_0 ∈ 1:qubit_count

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -60,7 +60,7 @@ test_instructions = [
         toffoli(1, 4, 3),
         swap(2, 4),
         iswap(4, 1),
-        iswap_dagger(1, 3),
+        # iswap_dagger(1, 3),
     ],
 ]
 
@@ -692,7 +692,7 @@ end
             end
 
             for gate in instructions_in_output
-                @test is_native_instruction(qpu, gate)
+                @test is_native_instruction(gate, Snowflurry.AnyonYukonConnectivity)
             end
         end
     end


### PR DESCRIPTION
in order for the transpilation to reject instructions given excluded positions on the connectivity, some refactoring was required, to add dependency injection for tests. 

`is_native_instruction` now considers the excluded positions on the connectivity

The `get_metadata` is setup so the Client is the one that retrieves it. It is hardcoded for now, but will eventually make an API call to the host server

I will update the documentation on these changes on a separate PR.