### PR TITLE
Update gates_display_symbols for PhasedShift with corresponding arg

### DIFF
--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -631,7 +631,7 @@ gates_display_symbols = Dict(
     RotationX => ["Rx(%s)", "theta"],
     RotationY => ["Ry(%s)", "theta"],
     RotationZ => ["Rz(%s)", "lambda"],
-    PhaseShift => ["P(%s)", "lambda"],
+    PhaseShift => ["P(%s)", "phi"],
     Universal => ["U(θ=%s,ϕ=%s,λ=%s)", "theta", "phi", "lambda"],
     ControlZ => [control_display_symbol, "Z"],
     ControlX => [control_display_symbol, "X"],


### PR DESCRIPTION
it's a really small PR but I think I spot a mistake.
Based on the [documentation](https://snowflurrysdk.github.io/Snowflurry.jl/dev/library/quantum_gates.html#Snowflurry.phase_shift) and the [struct definition](https://github.com/SnowflurrySDK/Snowflurry.jl/blob/main/src/core/quantum_gate.jl#L2011), the arg should be "phi" and not "lambda".