### PR TITLE
fix(get_num_qubits): remove `log2` calls

### DIFF
--- a/src/core/qobj.jl
+++ b/src/core/qobj.jl
@@ -1140,16 +1140,16 @@ function get_num_qubits(x::AbstractOperator)
     if num_rows != num_columns
         throw(ErrorException("$(typeof(x)) is not square"))
     end
-    qubit_count = log2(num_rows)
-    if mod(qubit_count, 1) != 0
+    if num_rows < 2 || count_ones(num_rows) != 1
         throw(
             DomainError(
-                qubit_count,
+                num_rows,
                 "$(typeof(x)) does not correspond to an integer number of qubits",
             ),
         )
     end
-    return Int(qubit_count)
+
+    return trailing_zeros(num_rows)
 end
 
 """
@@ -1172,16 +1172,16 @@ julia> get_num_qubits(ψ)
 ```
 """
 function get_num_qubits(x::Union{Ket,Bra})
-    qubit_count = log2(length(x))
-    if mod(qubit_count, 1) != 0
+    size = length(x)
+    if size < 2 || count_ones(size) != 1
         throw(
             DomainError(
-                qubit_count,
+                size,
                 "Ket or Bra does not correspond to an integer number of qubits",
             ),
         )
     end
-    return Int(qubit_count)
+    return trailing_zeros(size)
 end
 
 """

--- a/src/core/quantum_gate.jl
+++ b/src/core/quantum_gate.jl
@@ -1066,7 +1066,7 @@ function apply_operator!(
     # with first qubit on the rightmost side
     target_qubit_index_list =
         Vector{UInt64}([qubit_count - t for t in reverse(connected_qubits)])
-    target_qubit_index_count = UInt64(log2(N))
+    target_qubit_index_count = UInt64(trailing_zeros(N))
 
     diagonal_in_matrix = operator.data
 

--- a/test/gate.jl
+++ b/test/gate.jl
@@ -609,7 +609,7 @@ function Snowflurry.get_num_connected_qubits(gate::DenseGate)
     matrix = get_matrix(gate.operator)
     rows, cols = size(matrix)
     @assert rows == cols
-    num_connected_qubits = Int(round(log2(rows)))
+    num_connected_qubits = trailing_zeros(rows)
     @assert 2^num_connected_qubits == rows
     return num_connected_qubits
 end


### PR DESCRIPTION
In my testing, the calls to `log2` periodically fail on macOS Github runners. This change directly uses the julia functions `trailing_zeros` and `count_ones`, whose output does not depend on floating point comparisons.