### PR TITLE
docs: Clarifying the meaning of qubit_count

### DIFF
--- a/docs/src/tutorials/anyon_qpu.md
+++ b/docs/src/tutorials/anyon_qpu.md
@@ -144,6 +144,9 @@ q[1]:──Z_90────────────X_90────Z_90───
 q[2]:──────────Z_90────────────────────X_90────Z_90────Z────Z_90────X_90────Z_90─────────✲──
 ```
 
+!!! note
+	It may be beneficial to select specific qubits on the QPU in order to reduce the impact of noise on the results. For instance, one could select qubits 2 and 6 for the execution of a two-qubit circuit. This requires setting `qubit_count` to 6 for the construction of the `QuantumCircuit` since `qubit_count` represents the largest qubit index. Setting `qubit_count` to 2 will not enable the application of a quantum gate to qubit 6 even though gates are only applied to two qubits.
+
 The final circuit `c_transpiled` is now ready to be submitted to the QPU:
 
 ```julia

--- a/docs/src/tutorials/basics.md
+++ b/docs/src/tutorials/basics.md
@@ -10,8 +10,7 @@ using Snowflurry
 
 ```
 
-We can then create an empty [`QuantumCircuit`](@ref) by specifying the number of qubits (`qubit_count`) and classical bits (`bit_count`) the circuit will involve. 
-The classical bits (or result bits) are ordinary memory registries that each store the output of a [`Readout`](@ref) operation on a particular qubit.
+We can then create an empty [`QuantumCircuit`](@ref) by specifying the largest qubit index (`qubit_count`) and the number of classical bits (`bit_count`). In most cases, it can be assumed that `qubit_count` is equal to the number of qubits in the circuit. See [Circuit Transpilation](@ref) for more details about the relationship between the largest qubit index and the number of qubits. The classical bits (or result bits) are ordinary memory registries that each store the output of a [`Readout`](@ref) operation on a particular qubit.
 
 ```jldoctest basics
 c = QuantumCircuit(qubit_count = 2, bit_count = 2)

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -5,7 +5,7 @@
 
 A data structure to represent a *quantum circuit*.
 # Fields
-- `qubit_count::Int` -- number of qubits (i.e., quantum register size).
+- `qubit_count::Int` -- largest qubit index (e.g. specifying `qubit_count=n` enables the use of qubits 1 to n).
 - `bit_count::Int` -- Optional: number of classical bits (i.e., result register size). Defaults to `qubit_count` if unspecified.
 - `instructions::Vector{AbstractInstruction}` -- Optional: the sequence of `AbstractInstructions` (`Gates` and `Readouts`) that operate on qubits. Defaults to empty Vector.
 - `name::String` -- Optional: name of the circuit job, used to identify it when sending to a hardware or virtual QPU. 

--- a/src/core/quantum_circuit.jl
+++ b/src/core/quantum_circuit.jl
@@ -5,7 +5,7 @@
 
 A data structure to represent a *quantum circuit*.
 # Fields
-- `qubit_count::Int` -- largest qubit index (e.g. specifying `qubit_count=n` enables the use of qubits 1 to n).
+- `qubit_count::Int` -- largest qubit index (e.g., specifying `qubit_count=n` enables the use of qubits 1 to n).
 - `bit_count::Int` -- Optional: number of classical bits (i.e., result register size). Defaults to `qubit_count` if unspecified.
 - `instructions::Vector{AbstractInstruction}` -- Optional: the sequence of `AbstractInstructions` (`Gates` and `Readouts`) that operate on qubits. Defaults to empty Vector.
 - `name::String` -- Optional: name of the circuit job, used to identify it when sending to a hardware or virtual QPU. 


### PR DESCRIPTION
Documentation was added to clarify that `qubit_count` corresponds to the largest qubit index and not necessarily the number of qubits. Additional clarifications were also provided in the transpilation section of the documentation.