### PR TITLE
Feat/add excluded couplers to line connectivity

### DIFF
--- a/docs/src/library/qpu.md
+++ b/docs/src/library/qpu.md
@@ -14,7 +14,7 @@ SequentialTranspiler
 AllToAllConnectivity
 LineConnectivity
 LatticeConnectivity
-get_excluded_couplers
+get_excluded_connections
 path_search
 get_adjacency_list
 get_qubits_distance

--- a/docs/src/library/qpu.md
+++ b/docs/src/library/qpu.md
@@ -14,6 +14,7 @@ SequentialTranspiler
 AllToAllConnectivity
 LineConnectivity
 LatticeConnectivity
+get_excluded_couplers
 path_search
 get_adjacency_list
 get_qubits_distance

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -144,6 +144,7 @@ export
     get_connectivity,
     get_connectivity_label,
     get_excluded_positions,
+    get_excluded_couplers,
     get_adjacency_list,
     path_search,
     get_host,

--- a/src/Snowflurry.jl
+++ b/src/Snowflurry.jl
@@ -144,7 +144,7 @@ export
     get_connectivity,
     get_connectivity_label,
     get_excluded_positions,
-    get_excluded_couplers,
+    get_excluded_connections,
     get_adjacency_list,
     path_search,
     get_host,

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -354,20 +354,10 @@ julia> get_qubits_distance(3, 24, connectivity)
 ```
 
 """
-function get_qubits_distance(target_1::Int, target_2::Int, c::LineConnectivity)::Real
-    for e in c.excluded_positions
-        if target_1 ≤ e ≤ target_2
-            return Inf
-        end
-    end
-
-    abs(target_1 - target_2)
-end
-
 function get_qubits_distance(
     target_1::Int,
     target_2::Int,
-    connectivity::LatticeConnectivity,
+    connectivity::Union{LineConnectivity,LatticeConnectivity},
 )::Real
 
     path = path_search(target_1, target_2, connectivity)

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -275,9 +275,9 @@ function get_metadata(client::Client, qpu::UnionAnyonQPU)::Metadata
         "status" => machineMetadata["status"],
     )
 
-    if haskey(machineMetadata, "disconnectedQubits")
+    if haskey(machineMetadata, "disconnectedCouplers")
         output["excluded_positions"] =
-            convert(Vector{Int}, machineMetadata["disconnectedQubits"])
+            convert(Vector{Int}, machineMetadata["disconnectedCouplers"])
     else
         output["excluded_positions"] = Vector{Int}()
     end

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -275,9 +275,9 @@ function get_metadata(client::Client, qpu::UnionAnyonQPU)::Metadata
         "status" => machineMetadata["status"],
     )
 
-    if haskey(machineMetadata, "disconnectedCouplers")
+    if haskey(machineMetadata, "disconnectedQubits")
         output["excluded_positions"] =
-            convert(Vector{Int}, machineMetadata["disconnectedCouplers"])
+            convert(Vector{Int}, machineMetadata["disconnectedQubits"])
     else
         output["excluded_positions"] = Vector{Int}()
     end

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -263,9 +263,19 @@ get_excluded_positions(c::Union{LineConnectivity,LatticeConnectivity}) =
 get_excluded_positions(connectivity::AbstractConnectivity) =
     throw(NotImplementedError(:get_excluded_positions, connectivity))
 
-get_excluded_couplers(c::LineConnectivity) =
-    c.excluded_couplers
+"""
+    get_excluded_couplers(connectivity::LineConnectivity)::Vector{Tuple{Int, Int}}
 
+Return the list of `excluded_couplers` for the `LineConnectivity`.
+"""
+get_excluded_couplers(connectivity::LineConnectivity)::Vector{Tuple{Int, Int}} =
+    connectivity.excluded_couplers
+
+"""
+    get_excluded_couplers(connectivity::AbstractConnectivity)::Vector{Tuple{Int, Int}}
+
+Throws a NotImplementedError.
+"""
 get_excluded_couplers(connectivity::AbstractConnectivity) =
     throw(NotImplementedError(:get_excluded_couplers, connectivity))
 

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -65,7 +65,7 @@ function get_sorted_excluded_connections_for_line(
     sorted_connections = Vector{Tuple{Int,Int}}(undef, num_connections)
     for (i_connection, connection) in enumerate(excluded_connections)
         if connection[1] == connection[2]
-            throw(AssertionError("coupler $connection must connect to different qubits"))
+            throw(AssertionError("connection $connection must connect to different qubits"))
         end
 
         if connection[1] == connection[2] + 1
@@ -73,13 +73,14 @@ function get_sorted_excluded_connections_for_line(
         elseif connection[1] == connection[2] - 1
             sorted_connection = connection
         else
-            throw(AssertionError("coupler $connection is not nearest-neighbor"))
+            throw(AssertionError("connection $connection is not nearest-neighbor"))
         end
 
         if sorted_connection[1] < 1
             throw(
                 AssertionError(
-                    "coupler $connection must have qubits with indices " * "greater than 0",
+                    "connection $connection must have qubits with indices " *
+                    "greater than 0",
                 ),
             )
         end
@@ -87,7 +88,7 @@ function get_sorted_excluded_connections_for_line(
         if sorted_connection[2] > dimension
             throw(
                 AssertionError(
-                    "coupler $connection must have qubits with indices " *
+                    "connection $connection must have qubits with indices " *
                     "smaller than $(dimension+1)",
                 ),
             )
@@ -96,7 +97,9 @@ function get_sorted_excluded_connections_for_line(
         sorted_connections[i_connection] = sorted_connection
     end
 
-    @assert sorted_connections == unique(sorted_connections) "excluded_connections must be unique"
+    if sorted_connections != unique(sorted_connections)
+        throw(AssertionError("excluded_connections must be unique"))
+    end
     return sorted_connections
 end
 

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -13,6 +13,9 @@ This connectivity type is encountered in `QPUs` such as the [`AnyonYukonQPU`](@r
 - `excluded_positions::Vector{Int}` -- Optional: List of qubits on the connectivity which are disabled, and cannot be interacted with. Elements in Vector must be unique.
 - `excluded_connections::Vector{Tuple{Int, Int}}` -- Optional: List of couplers on the connectivity which are disabled, and cannot be interacted with. Elements in Vector must be unique.
 
+Note: Every excluded connection is sorted in ascending order (i.e. connection (2, 1) will be
+changed to (1, 2)).
+
 
 # Example
 ```jldoctest
@@ -20,10 +23,11 @@ julia> connectivity = LineConnectivity(6)
 LineConnectivity{6}
 1──2──3──4──5──6
 
-julia> connectivity = LineConnectivity(6, [1,2,3])
+julia> connectivity = LineConnectivity(6, [1,2,3], [(3, 2), (3, 4)])
 LineConnectivity{6}
 1──2──3──4──5──6
 excluded positions: [1, 2, 3]
+excluded connections: [(2, 3), (3, 4)]
 
 ```
 """

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -657,16 +657,23 @@ function get_adjacency_list(connectivity::LineConnectivity)::Dict{Int,Vector{Int
         if !(target in connectivity.excluded_positions)
             neighbors = Vector{Int}()
 
-            if target - 1 > 0 && !(target - 1 in connectivity.excluded_positions)
+            if target - 1 > 0 &&
+               !(target - 1 in connectivity.excluded_positions) &&
+               !((target - 1, target) in connectivity.excluded_connections)
+
                 push!(neighbors, target - 1)
             end
 
             if target + 1 ≤ connectivity.dimension &&
-               !(target + 1 in connectivity.excluded_positions)
+               !(target + 1 in connectivity.excluded_positions) &&
+               !((target, target + 1) in connectivity.excluded_connections)
+
                 push!(neighbors, target + 1)
             end
 
-            adjacency_list[target] = neighbors
+            if !isempty(neighbors)
+                adjacency_list[target] = neighbors
+            end
         end
     end
 

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -606,7 +606,8 @@ end
     get_adjacency_list(connectivity::AbstractConnectivity)::Dict{Int,Vector{Int}}
 
 Given an object of type `AbstractConnectivity`, `get_adjacency_list` returns a Dict where `key => value` pairs
-are each qubit number => an Vector of the qubits that are adjacent (neighbors) to it on this particular connectivity.
+are each qubit number => a Vector of the qubits that are adjacent (neighbors) to it on this particular connectivity.
+Positions in `connectivity.excluded_positions` are not given a key in the adjacency list.
 
 # Example
 ```jldoctest
@@ -679,9 +680,7 @@ function get_adjacency_list(connectivity::LineConnectivity)::Dict{Int,Vector{Int
                 push!(neighbors, target + 1)
             end
 
-            if !isempty(neighbors)
-                adjacency_list[target] = neighbors
-            end
+            adjacency_list[target] = neighbors
         end
     end
 

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -44,10 +44,10 @@ struct LineConnectivity <: AbstractConnectivity
             @assert e ≤ dimension "elements in excluded_positions must be ≤ $dimension"
         end
 
-        sorted_couplers =
+        sorted_connections =
             get_sorted_excluded_connections_for_line(dimension, excluded_connections)
 
-        new(dimension, excluded_positions, sorted_couplers)
+        new(dimension, excluded_positions, sorted_connections)
     end
 end
 
@@ -56,43 +56,43 @@ function get_sorted_excluded_connections_for_line(
     excluded_connections::Vector{Tuple{Int,Int}},
 )::Vector{Tuple{Int,Int}}
 
-    num_couplers = length(excluded_connections)
-    sorted_couplers = Vector{Tuple{Int,Int}}(undef, num_couplers)
-    for (i_coupler, coupler) in enumerate(excluded_connections)
-        if coupler[1] == coupler[2]
-            throw(AssertionError("coupler $coupler must connect to different qubits"))
+    num_connections = length(excluded_connections)
+    sorted_connections = Vector{Tuple{Int,Int}}(undef, num_connections)
+    for (i_connection, connection) in enumerate(excluded_connections)
+        if connection[1] == connection[2]
+            throw(AssertionError("coupler $connection must connect to different qubits"))
         end
 
-        if coupler[1] == coupler[2] + 1
-            sorted_coupler = (coupler[2], coupler[1])
-        elseif coupler[1] == coupler[2] - 1
-            sorted_coupler = coupler
+        if connection[1] == connection[2] + 1
+            sorted_connection = (connection[2], connection[1])
+        elseif connection[1] == connection[2] - 1
+            sorted_connection = connection
         else
-            throw(AssertionError("coupler $coupler is not nearest-neighbor"))
+            throw(AssertionError("coupler $connection is not nearest-neighbor"))
         end
 
-        if sorted_coupler[1] < 1
+        if sorted_connection[1] < 1
             throw(
                 AssertionError(
-                    "coupler $coupler must have qubits with indices " * "greater than 0",
+                    "coupler $connection must have qubits with indices " * "greater than 0",
                 ),
             )
         end
 
-        if sorted_coupler[2] > dimension
+        if sorted_connection[2] > dimension
             throw(
                 AssertionError(
-                    "coupler $coupler must have qubits with indices " *
+                    "coupler $connection must have qubits with indices " *
                     "smaller than $(dimension+1)",
                 ),
             )
         end
 
-        sorted_couplers[i_coupler] = sorted_coupler
+        sorted_connections[i_connection] = sorted_connection
     end
 
-    @assert sorted_couplers == unique(sorted_couplers) "excluded_connections must be unique"
-    return sorted_couplers
+    @assert sorted_connections == unique(sorted_connections) "excluded_connections must be unique"
+    return sorted_connections
 end
 
 """
@@ -237,7 +237,7 @@ function Base.show(io::IO, connectivity::LineConnectivity)
         println(io, "excluded positions: $(connectivity.excluded_positions)")
     end
     if !isempty(connectivity.excluded_connections)
-        println(io, "excluded couplers: $(connectivity.excluded_connections)")
+        println(io, "excluded connections: $(connectivity.excluded_connections)")
     end
 end
 
@@ -840,9 +840,9 @@ function path_search(
         end
     end
 
-    for coupler in get_excluded_connections(connectivity)
-        if (origin <= coupler[1] & coupler[2] <= target) ||
-           (target <= coupler[1] & coupler[2] <= origin)
+    for connection in get_excluded_connections(connectivity)
+        if (origin <= connection[1] & connection[2] <= target) ||
+           (target <= connection[1] & connection[2] <= origin)
 
             return []
         end

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -11,10 +11,11 @@ This connectivity type is encountered in `QPUs` such as the [`AnyonYukonQPU`](@r
 # Fields
 - `dimension         ::Int` -- Qubit count in this connectivity.
 - `excluded_positions::Vector{Int}` -- Optional: List of qubits on the connectivity which are disabled, and cannot be interacted with. Elements in Vector must be unique.
-- `excluded_connections::Vector{Tuple{Int, Int}}` -- Optional: List of couplers on the connectivity which are disabled, and cannot be interacted with. Elements in Vector must be unique.
+- `excluded_connections::Vector{Tuple{Int, Int}}` -- Optional: List of connections between qubits which are disabled and cannot perform 2-qubit gates. Elements in Vector must be unique.
 
-Note: Every excluded connection is sorted in ascending order (i.e. connection (2, 1) will be
-changed to (1, 2)).
+!!! note
+    Every excluded connection is sorted in ascending order (i.e. connection (2, 1) will be
+    changed to (1, 2)).
 
 
 # Example

--- a/test/mock_functions.jl
+++ b/test/mock_functions.jl
@@ -242,10 +242,6 @@ yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedConnections\":[[4, 5, 6]]}]",
 )
 
-yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
-    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedCouplers\":[[4, 5, 6]]}]",
-)
-
 yukonMetadataWithOfflineStatus = makeMetadataResponseJSON(
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"offline\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\"}]",
 )

--- a/test/mock_functions.jl
+++ b/test/mock_functions.jl
@@ -246,7 +246,7 @@ yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
 )
 
 yamaskaMetadataWithExcludedComponents = makeMetadataResponseJSON(
-    "[{\"id\":\"6b770575-c40f-4d81-a9de-b1969a028ca5\",\"name\":\"yamaska\",\"hostServer\":\"yamaska.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"CalculQC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202301\"},\"qubitCount\":24,\"bitCount\":24,\"connectivity\":\"lattice\",\"disconnectedCouplers\":[7,8,9,10,11,12],\"excludedCouplers\":[[7, 12], [12, 8]]}]",
+    "[{\"id\":\"6b770575-c40f-4d81-a9de-b1969a028ca5\",\"name\":\"yamaska\",\"hostServer\":\"yamaska.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"CalculQC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202301\"},\"qubitCount\":24,\"bitCount\":24,\"connectivity\":\"lattice\",\"disconnectedQubits\":[7,8,9,10,11,12],\"disconnectedConnections\":[[7, 12], [12, 8]]}]",
 )
 
 yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(

--- a/test/mock_functions.jl
+++ b/test/mock_functions.jl
@@ -231,6 +231,7 @@ yamaskaMetadata = makeMetadataResponseJSON(
 )
 
 yukonMetadataWithExcludedComponents = makeMetadataResponseJSON(
+<<<<<<< HEAD
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedConnections\":[[4, 5], [5, 6]]}]",
 )
 
@@ -240,6 +241,17 @@ yamaskaMetadataWithExcludedComponents = makeMetadataResponseJSON(
 
 yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedConnections\":[[4, 5, 6]]}]",
+=======
+    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedCouplers\":[3,4,5,6],\"excludedCouplers\":[[4, 5], [5, 6]]}]",
+)
+
+yamaskaMetadataWithExcludedComponents = makeMetadataResponseJSON(
+    "[{\"id\":\"6b770575-c40f-4d81-a9de-b1969a028ca5\",\"name\":\"yamaska\",\"hostServer\":\"yamaska.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"CalculQC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202301\"},\"qubitCount\":24,\"bitCount\":24,\"connectivity\":\"lattice\",\"disconnectedCouplers\":[7,8,9,10,11,12],\"excludedCouplers\":[[7, 12], [12, 8]]}]",
+)
+
+yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
+    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedCouplers\":[3,4,5,6],\"excludedCouplers\":[[4, 5, 6]]}]",
+>>>>>>> 9fd9e0d (refactor: rename to disconnectedCouplers and excluded_connections)
 )
 
 yukonMetadataWithOfflineStatus = makeMetadataResponseJSON(

--- a/test/mock_functions.jl
+++ b/test/mock_functions.jl
@@ -243,7 +243,7 @@ yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
 )
 
 yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
-    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"excludedCouplers\":[[4, 5, 6]]}]",
+    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedCouplers\":[[4, 5, 6]]}]",
 )
 
 yukonMetadataWithOfflineStatus = makeMetadataResponseJSON(

--- a/test/mock_functions.jl
+++ b/test/mock_functions.jl
@@ -242,6 +242,10 @@ yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedConnections\":[[4, 5, 6]]}]",
 )
 
+yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
+    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"excludedCouplers\":[[4, 5, 6]]}]",
+)
+
 yukonMetadataWithOfflineStatus = makeMetadataResponseJSON(
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"offline\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\"}]",
 )

--- a/test/mock_functions.jl
+++ b/test/mock_functions.jl
@@ -231,7 +231,6 @@ yamaskaMetadata = makeMetadataResponseJSON(
 )
 
 yukonMetadataWithExcludedComponents = makeMetadataResponseJSON(
-<<<<<<< HEAD
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedConnections\":[[4, 5], [5, 6]]}]",
 )
 
@@ -241,17 +240,6 @@ yamaskaMetadataWithExcludedComponents = makeMetadataResponseJSON(
 
 yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
     "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedQubits\":[3,4,5,6],\"disconnectedConnections\":[[4, 5, 6]]}]",
-=======
-    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedCouplers\":[3,4,5,6],\"excludedCouplers\":[[4, 5], [5, 6]]}]",
-)
-
-yamaskaMetadataWithExcludedComponents = makeMetadataResponseJSON(
-    "[{\"id\":\"6b770575-c40f-4d81-a9de-b1969a028ca5\",\"name\":\"yamaska\",\"hostServer\":\"yamaska.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"CalculQC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202301\"},\"qubitCount\":24,\"bitCount\":24,\"connectivity\":\"lattice\",\"disconnectedQubits\":[7,8,9,10,11,12],\"disconnectedConnections\":[[7, 12], [12, 8]]}]",
-)
-
-yukonMetadataWithInvalidCouplerEntries = makeMetadataResponseJSON(
-    "[{\"id\":\"64c5ec18-03a8-480e-a4dc-9377c109e659\",\"name\":\"yukon\",\"hostServer\":\"yukon.anyonsys.com\",\"type\":\"quantum-computer\",\"owner\":\"DRDC\",\"status\":\"online\",\"metadata\":{\"Serial Number\":\"ANYK202201\"},\"qubitCount\":6,\"bitCount\":6,\"connectivity\":\"linear\",\"disconnectedCouplers\":[3,4,5,6],\"excludedCouplers\":[[4, 5, 6]]}]",
->>>>>>> 9fd9e0d (refactor: rename to disconnectedCouplers and excluded_connections)
 )
 
 yukonMetadataWithOfflineStatus = makeMetadataResponseJSON(

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -586,24 +586,24 @@ end
         [2, 2],
     )
 
-    @test_throws AssertionError("coupler (3, 3) must connect to different qubits") LineConnectivity(
+    @test_throws AssertionError("connection (3, 3) must connect to different qubits") LineConnectivity(
         12,
         Int[],
         [(3, 3)],
     )
 
-    @test_throws AssertionError("coupler (1, 3) is not nearest-neighbor") LineConnectivity(
+    @test_throws AssertionError("connection (1, 3) is not nearest-neighbor") LineConnectivity(
         12,
         Int[],
         [(1, 3)],
     )
 
     @test_throws AssertionError(
-        "coupler (0, 1) must have qubits with indices greater than 0",
+        "connection (0, 1) must have qubits with indices greater than 0",
     ) LineConnectivity(12, Int[], [(0, 1)])
 
     @test_throws AssertionError(
-        "coupler (12, 13) must have qubits with indices smaller than 13",
+        "connection (12, 13) must have qubits with indices smaller than 13",
     ) LineConnectivity(12, Int[], [(12, 13)])
 
     @test_throws AssertionError("excluded_connections must be unique") LineConnectivity(

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -613,6 +613,7 @@ end
     )
 
     @test isinf(get_qubits_distance(1, 12, connectivity))
+    @test isinf(get_qubits_distance(1, 12, LineConnectivity(12, Int[], [(6, 5)])))
 
     io = IOBuffer()
 

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -556,7 +556,8 @@ end
           "\n"
 
     @test path_search(1, 12, connectivity) == []
-    @test path_search(7, 4, connectivity) == Vector{Int}(collect(4:7))
+    @test path_search(7, 4, connectivity) == []
+    @test path_search(7, 5, connectivity) == Vector{Int}(collect(5:7))
     @test path_search(1, 1, connectivity) == []
 
     exclusion_cases = [[5], [5, 7], [8]]

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -509,12 +509,12 @@ end
 @testset "AbstractConnectivity: excluded positions and connections" begin
 
     excluded_positions = [1, 2, 3, 9, 10]
-    excluded_connections = [(2, 3), (6, 5)]
+    excluded_connections = [(2, 3), (5, 4), (5, 6)]
 
     connectivity = LineConnectivity(12, excluded_positions, excluded_connections)
 
     @test get_excluded_positions(connectivity) == excluded_positions
-    @test get_excluded_connections(connectivity) == [(2, 3), (5, 6)]
+    @test get_excluded_connections(connectivity) == [(2, 3), (4, 5), (5, 6)]
 
     alternate_positions = Snowflurry.with_excluded_positions(
         LineConnectivity(12, [1], excluded_connections),
@@ -535,8 +535,8 @@ end
     @test connectivity.excluded_connections == alternate_connection.excluded_connections
 
     expected_adjacency_list = Dict{Int,Vector{Int}}(
-        4 => [5],
-        5 => [4],
+        4 => [],
+        5 => [],
         6 => [7],
         7 => [6, 8],
         8 => [7],
@@ -552,12 +552,12 @@ end
           "LineConnectivity{12}\n" *
           "1──2──3──4──5──6──7──8──9──10──11──12\n" *
           "excluded positions: [1, 2, 3, 9, 10]\n" *
-          "excluded connections: [(2, 3), (5, 6)]\n" *
+          "excluded connections: [(2, 3), (4, 5), (5, 6)]\n" *
           "\n"
 
     @test path_search(1, 12, connectivity) == []
     @test path_search(7, 4, connectivity) == []
-    @test path_search(7, 5, connectivity) == Vector{Int}(collect(5:7))
+    @test path_search(8, 6, connectivity) == Vector{Int}(collect(6:8))
     @test path_search(1, 1, connectivity) == []
 
     exclusion_cases = [[5], [5, 7], [8]]

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -535,8 +535,7 @@ end
     @test connectivity.excluded_connections == alternate_couplers.excluded_connections
 
     expected_adjacency_list = Dict{Int,Vector{Int}}(
-        4 => [5],
-        5 => [4, 6],
+        5 => [6],
         6 => [5, 7],
         7 => [6, 8],
         8 => [7],

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -509,12 +509,12 @@ end
 @testset "AbstractConnectivity: excluded positions and connections" begin
 
     excluded_positions = [1, 2, 3, 9, 10]
-    excluded_connections = [(2, 3), (5, 4)]
+    excluded_connections = [(2, 3), (6, 5)]
 
     connectivity = LineConnectivity(12, excluded_positions, excluded_connections)
 
     @test get_excluded_positions(connectivity) == excluded_positions
-    @test get_excluded_connections(connectivity) == [(2, 3), (4, 5)]
+    @test get_excluded_connections(connectivity) == [(2, 3), (5, 6)]
 
     alternate_positions = Snowflurry.with_excluded_positions(
         LineConnectivity(12, [1], excluded_connections),
@@ -535,8 +535,9 @@ end
     @test connectivity.excluded_connections == alternate_connection.excluded_connections
 
     expected_adjacency_list = Dict{Int,Vector{Int}}(
-        5 => [6],
-        6 => [5, 7],
+        4 => [5],
+        5 => [4],
+        6 => [7],
         7 => [6, 8],
         8 => [7],
         11 => [12],
@@ -551,7 +552,7 @@ end
           "LineConnectivity{12}\n" *
           "1──2──3──4──5──6──7──8──9──10──11──12\n" *
           "excluded positions: [1, 2, 3, 9, 10]\n" *
-          "excluded connections: [(2, 3), (4, 5)]\n" *
+          "excluded connections: [(2, 3), (5, 6)]\n" *
           "\n"
 
     @test path_search(1, 12, connectivity) == []

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -506,7 +506,7 @@ end
 end
 
 
-@testset "AbstractConnectivity: excluded positions and couplers" begin
+@testset "AbstractConnectivity: excluded positions and connections" begin
 
     excluded_positions = [1, 2, 3, 9, 10]
     excluded_connections = [(2, 3), (5, 4)]
@@ -525,14 +525,14 @@ end
     @test connectivity.excluded_positions == alternate_positions.excluded_positions
     @test connectivity.excluded_connections == alternate_positions.excluded_connections
 
-    alternate_couplers = Snowflurry.with_excluded_connections(
+    alternate_connection = Snowflurry.with_excluded_connections(
         LineConnectivity(12, excluded_positions),
         excluded_connections,
     )
 
-    @test connectivity.dimension == alternate_couplers.dimension
-    @test connectivity.excluded_positions == alternate_couplers.excluded_positions
-    @test connectivity.excluded_connections == alternate_couplers.excluded_connections
+    @test connectivity.dimension == alternate_connection.dimension
+    @test connectivity.excluded_positions == alternate_connection.excluded_positions
+    @test connectivity.excluded_connections == alternate_connection.excluded_connections
 
     expected_adjacency_list = Dict{Int,Vector{Int}}(
         5 => [6],
@@ -551,7 +551,7 @@ end
           "LineConnectivity{12}\n" *
           "1──2──3──4──5──6──7──8──9──10──11──12\n" *
           "excluded positions: [1, 2, 3, 9, 10]\n" *
-          "excluded couplers: [(2, 3), (4, 5)]\n" *
+          "excluded connections: [(2, 3), (4, 5)]\n" *
           "\n"
 
     @test path_search(1, 12, connectivity) == []

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -509,30 +509,30 @@ end
 @testset "AbstractConnectivity: excluded positions and couplers" begin
 
     excluded_positions = [1, 2, 3, 9, 10]
-    excluded_couplers = [(2, 3), (5, 4)]
+    excluded_connections = [(2, 3), (5, 4)]
 
-    connectivity = LineConnectivity(12, excluded_positions, excluded_couplers)
+    connectivity = LineConnectivity(12, excluded_positions, excluded_connections)
 
     @test get_excluded_positions(connectivity) == excluded_positions
-    @test get_excluded_couplers(connectivity) == [(2, 3), (4, 5)]
+    @test get_excluded_connections(connectivity) == [(2, 3), (4, 5)]
 
-    alternate_positions =
-        Snowflurry.with_excluded_positions(
-            LineConnectivity(12, [1], excluded_couplers), excluded_positions
-            )
+    alternate_positions = Snowflurry.with_excluded_positions(
+        LineConnectivity(12, [1], excluded_connections),
+        excluded_positions,
+    )
 
     @test connectivity.dimension == alternate_positions.dimension
     @test connectivity.excluded_positions == alternate_positions.excluded_positions
-    @test connectivity.excluded_couplers == alternate_positions.excluded_couplers
+    @test connectivity.excluded_connections == alternate_positions.excluded_connections
 
-    alternate_couplers =
-        Snowflurry.with_excluded_couplers(
-            LineConnectivity(12, excluded_positions), excluded_couplers
-            )
+    alternate_couplers = Snowflurry.with_excluded_connections(
+        LineConnectivity(12, excluded_positions),
+        excluded_connections,
+    )
 
     @test connectivity.dimension == alternate_couplers.dimension
     @test connectivity.excluded_positions == alternate_couplers.excluded_positions
-    @test connectivity.excluded_couplers == alternate_couplers.excluded_couplers
+    @test connectivity.excluded_connections == alternate_couplers.excluded_connections
 
     expected_adjacency_list = Dict{Int,Vector{Int}}(
         4 => [5],
@@ -586,40 +586,30 @@ end
         [2, 2],
     )
 
-    @test_throws AssertionError(
-        "coupler (3, 3) must connect to different qubits"
-        ) LineConnectivity(
+    @test_throws AssertionError("coupler (3, 3) must connect to different qubits") LineConnectivity(
         12,
         Int[],
-        [(3, 3)]
+        [(3, 3)],
     )
 
     @test_throws AssertionError("coupler (1, 3) is not nearest-neighbor") LineConnectivity(
         12,
         Int[],
-        [(1, 3)]
+        [(1, 3)],
     )
 
     @test_throws AssertionError(
-        "coupler (0, 1) must have qubits with indices greater than 0"
-        ) LineConnectivity(
-        12,
-        Int[],
-        [(0, 1)]
-    )
+        "coupler (0, 1) must have qubits with indices greater than 0",
+    ) LineConnectivity(12, Int[], [(0, 1)])
 
     @test_throws AssertionError(
-        "coupler (12, 13) must have qubits with indices smaller than 13"
-        ) LineConnectivity(
-        12,
-        Int[],
-        [(12, 13)]
-    )
+        "coupler (12, 13) must have qubits with indices smaller than 13",
+    ) LineConnectivity(12, Int[], [(12, 13)])
 
-    @test_throws AssertionError("excluded_couplers must be unique") LineConnectivity(
+    @test_throws AssertionError("excluded_connections must be unique") LineConnectivity(
         12,
         Int[],
-        [(1, 2), (2, 1)]
+        [(1, 2), (2, 1)],
     )
 
     @test isinf(get_qubits_distance(1, 12, connectivity))
@@ -753,11 +743,11 @@ end
     )
     @test_throws NotImplementedError get_excluded_positions(NonExistentConnectivity())
 
-    @test_throws NotImplementedError Snowflurry.with_excluded_couplers(
+    @test_throws NotImplementedError Snowflurry.with_excluded_connections(
         NonExistentConnectivity(),
-        Tuple{Int, Int}[],
+        Tuple{Int,Int}[],
     )
-    @test_throws NotImplementedError get_excluded_couplers(NonExistentConnectivity())
+    @test_throws NotImplementedError get_excluded_connections(NonExistentConnectivity())
 end
 
 @testset "get_qubits_distance" begin


### PR DESCRIPTION
Adds `excluded_couplers` to `LineConnectivity`.

Issue #417 