### PR TITLE
Refactor/remove excluded positions from native transpiler

### DIFF
--- a/docs/src/library/qpu.md
+++ b/docs/src/library/qpu.md
@@ -18,4 +18,5 @@ get_excluded_connections
 path_search
 get_adjacency_list
 get_qubits_distance
+is_native_instruction
 ```

--- a/docs/src/library/qpu.md
+++ b/docs/src/library/qpu.md
@@ -19,4 +19,5 @@ path_search
 get_adjacency_list
 get_qubits_distance
 is_native_instruction
+is_native_circuit
 ```

--- a/docs/src/tutorials/anyon_qpu.md
+++ b/docs/src/tutorials/anyon_qpu.md
@@ -149,7 +149,7 @@ SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoN
 1──2──3──4──5──6
 ), CastSwapToCZGateTranspiler()  …  SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler(), RejectNonNativeInstructionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
-), RejectGatesOnExcludedPositionsTranspiler(LineConnectivity{6}
+, DataType[Snowflurry.Identity, Snowflurry.PhaseShift, Snowflurry.Pi8, Snowflurry.Pi8Dagger, Snowflurry.SigmaX, Snowflurry.SigmaY, Snowflurry.SigmaZ, Snowflurry.X90, Snowflurry.XM90, Snowflurry.Y90, Snowflurry.YM90, Snowflurry.Z90, Snowflurry.ZM90, Snowflurry.ControlZ]), RejectGatesOnExcludedPositionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
 ), RejectGatesOnExcludedConnectionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -374,6 +374,42 @@ end
 
 const GeometricConnectivity = Union{LineConnectivity,LatticeConnectivity}
 
+"""
+    is_native_instruction(
+        gate::Union{Gate},
+        connectivity::Union{LineConnectivity,LatticeConnectivity},
+        native_gates::Vector{DataType} = set_of_native_gates,
+    )::Bool
+
+Returns `true` if the `gate` is a native instruction for the `connectivity` and the list of
+possible `native_gates`. The native gates for the Anyon QPUs are used by default.
+
+A native instruction is defined as an instruction that is in `native_gates` and that
+satisifies the `connecitivity`. It does not check to determine if the `gate` is placed at
+the `excluded_positions` or `excluded_connections` of the `connectivity`.
+
+# Example
+
+```jldoctest  
+julia> connectivity = LineConnectivity(3)
+LineConnectivity{3}
+1──2──3
+
+
+julia> is_native_instruction(control_z(1, 2), connectivity)
+true
+
+julia> is_native_instruction(control_z(1, 3), connectivity)
+false
+
+julia> is_native_instruction(toffoli(1, 2, 3), connectivity)
+false
+
+julia> is_native_instruction(toffoli(1, 2, 3), connectivity, [Snowflurry.Toffoli])
+true
+
+```
+"""
 function is_native_instruction(
     gate::Gate,
     connectivity::GeometricConnectivity,
@@ -399,7 +435,17 @@ function is_native_instruction(
     return (typeof(get_gate_symbol(gate)) in native_gates)
 end
 
+"""
+    is_native_instruction(
+        readout::Readout,
+        connectivity::Union{LineConnectivity,LatticeConnectivity},
+        native_gates::Vector{DataType} = set_of_native_gates,
+    )::Bool
 
+Always returns `true` since `readout` is a native instruction.
+
+```
+"""
 function is_native_instruction(
     readout::Readout,
     connectivity::GeometricConnectivity,
@@ -610,7 +656,7 @@ SequentialTranspiler(Transpiler[CircuitContainsAReadoutTranspiler(), ReadoutsDoN
 1──2──3──4──5──6
 ), CastSwapToCZGateTranspiler()  …  SimplifyTrivialGatesTranspiler(1.0e-6), CastUniversalToRzRxRzTranspiler(), SimplifyRxGatesTranspiler(1.0e-6), CastRxToRzAndHalfRotationXTranspiler(), CompressRzGatesTranspiler(), SimplifyRzGatesTranspiler(1.0e-6), ReadoutsAreFinalInstructionsTranspiler(), RejectNonNativeInstructionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
-), RejectGatesOnExcludedPositionsTranspiler(LineConnectivity{6}
+, DataType[Snowflurry.Identity, Snowflurry.PhaseShift, Snowflurry.Pi8, Snowflurry.Pi8Dagger, Snowflurry.SigmaX, Snowflurry.SigmaY, Snowflurry.SigmaZ, Snowflurry.X90, Snowflurry.XM90, Snowflurry.Y90, Snowflurry.YM90, Snowflurry.Z90, Snowflurry.ZM90, Snowflurry.ControlZ]), RejectGatesOnExcludedPositionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6
 ), RejectGatesOnExcludedConnectionsTranspiler(LineConnectivity{6}
 1──2──3──4──5──6

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -439,7 +439,12 @@ function is_native_instruction(
     return (typeof(get_gate_symbol(gate)) in native_gates)
 end
 
-function is_native_instruction(gate::Gate, connectivity::AllToAllConnectivity)::Bool
+function is_native_instruction(
+    ::Gate,
+    connectivity::AbstractConnectivity,
+    ::Vector{DataType} = set_of_native_gates,
+)::Bool
+
     throw(NotImplementedError(:is_native_instruction, connectivity))
 end
 
@@ -479,6 +484,15 @@ function is_native_instruction(
 
     num_qubits = get_num_qubits(connectivity)
     return readout.connected_qubit <= num_qubits
+end
+
+function is_native_instruction(
+    ::Readout,
+    connectivity::AbstractConnectivity,
+    ::Vector{DataType} = set_of_native_gates,
+)::Bool
+
+    throw(NotImplementedError(:is_native_instruction, connectivity))
 end
 
 """
@@ -602,9 +616,9 @@ function is_native_circuit(
 end
 
 function is_native_circuit(
-    circuit::QuantumCircuit,
-    connectivity::AllToAllConnectivity,
-    native_gates::Vector{DataType} = set_of_native_gates,
+    ::QuantumCircuit,
+    connectivity::AbstractConnectivity,
+    ::Vector{DataType} = set_of_native_gates,
 )::Tuple{Bool,String}
 
     throw(NotImplementedError(:is_native_circuit, connectivity))

--- a/src/anyon/anyon.jl
+++ b/src/anyon/anyon.jl
@@ -385,7 +385,7 @@ Returns `true` if the `gate` is a native instruction for the `connectivity` and 
 possible `native_gates`. The native gates for the Anyon QPUs are used by default.
 
 A native instruction is defined as an instruction that is in `native_gates` and that
-satisifies the `connecitivity`. It does not check to determine if the `gate` is placed at
+satisifies the `connectivity`. It does not check to determine if the `gate` is placed at
 the `excluded_positions` or `excluded_connections` of the `connectivity`.
 
 # Example
@@ -442,7 +442,24 @@ end
         native_gates::Vector{DataType} = set_of_native_gates,
     )::Bool
 
-Always returns `true` since `readout` is a native instruction.
+Returns `true` if the `readout` satisfies the connectivity.
+
+It does not check to determine if the `gate` is placed at the `excluded_positions` of the
+`connectivity`.
+
+# Example
+
+```jldoctest  
+julia> connectivity = LineConnectivity(3)
+LineConnectivity{3}
+1──2──3
+
+
+julia> is_native_instruction(readout(2, 2), connectivity)
+true
+
+julia> is_native_instruction(readout(4, 4), connectivity)
+false
 
 ```
 """
@@ -452,9 +469,76 @@ function is_native_instruction(
     native_gates::Vector{DataType} = set_of_native_gates,
 )::Bool
 
-    return true
+    num_qubits = get_num_qubits(connectivity)
+    return readout.connected_qubit <= num_qubits
 end
 
+"""
+    is_native_circuit(
+        circuit::QuantumCircuit,
+        connectivity::GeometricConnectivity,
+        native_gates::Vector{DataType} = set_of_native_gates,
+    )::Tuple{Bool,String}
+
+Returns `(true, "")` if the `circuit` only contains native instructions for the
+`connectivity` and the list of possible `native_gates`. It returns
+`(false, "error_message")` otherwise. The native gates for the Anyon QPUs are used by
+default.
+
+See [`is_native_instruction`](@ref) for more details about the identification of native
+instructions.
+
+# Example
+
+```jldoctest  
+julia> connectivity = LineConnectivity(3)
+LineConnectivity{3}
+1──2──3
+
+
+julia> native_circuit = QuantumCircuit(
+           qubit_count = 3,
+           instructions = [sigma_x(1), control_z(2, 3)]
+       )
+Quantum Circuit Object:
+   qubit_count: 3 
+   bit_count: 3 
+q[1]:──X───────
+               
+q[2]:───────*──
+            |  
+q[3]:───────Z──
+               
+
+julia> is_native_circuit(native_circuit, connectivity)
+(true, "")
+
+julia> foreign_circuit = QuantumCircuit(
+           qubit_count = 3,
+           instructions = [sigma_x(1), toffoli(1, 2, 3)]
+       )
+Quantum Circuit Object:
+   qubit_count: 3 
+   bit_count: 3 
+q[1]:──X────*──
+            |  
+q[2]:───────*──
+            |  
+q[3]:───────X──
+               
+
+julia> is_native_circuit(foreign_circuit, connectivity)
+(false, "Instruction type Gate{Snowflurry.Toffoli} with targets [1, 2, 3] is not native on the connectivity")
+
+julia> is_native_circuit(
+            foreign_circuit,
+            connectivity,
+            [Snowflurry.Toffoli, Snowflurry.SigmaX]
+        )
+(true, "")
+
+```
+"""
 function is_native_circuit(
     circuit::QuantumCircuit,
     connectivity::GeometricConnectivity,

--- a/src/core/connectivity.jl
+++ b/src/core/connectivity.jl
@@ -292,6 +292,8 @@ function get_sorted_excluded_connections_for_lattice(
     return sorted_connections
 end
 
+const GeometricConnectivity = Union{LineConnectivity,LatticeConnectivity}
+
 function Base.show(io::IO, connectivity::LatticeConnectivity)
     println(
         io,

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2452,11 +2452,19 @@ struct RejectNonNativeInstructionsTranspiler <: Transpiler
     native_gates::Vector{DataType}
 
     function RejectNonNativeInstructionsTranspiler(
-        connectivity::AbstractConnectivity,
+        connectivity::Union{LineConnectivity,LatticeConnectivity},
         native_gates::Vector{DataType} = set_of_native_gates,
     )
 
         return new(connectivity, native_gates)
+    end
+
+    function RejectNonNativeInstructionsTranspiler(
+        connectivity::AllToAllConnectivity,
+        native_gates::Vector{DataType} = set_of_native_gates,
+    )
+
+        throw(NotImplementedError(:RejectNonNativeInstructionsTranspiler, connectivity))
     end
 end
 

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2468,6 +2468,126 @@ struct RejectNonNativeInstructionsTranspiler <: Transpiler
     end
 end
 
+"""
+    transpile(
+        transpiler::RejectNonNativeInstructionsTranspiler,
+        circuit::QuantumCircuit
+    )::QuantumCircuit
+
+Throws a `DomainError` if a non-native `Instruction` is found in the `circuit`. The
+`circuit` remains unchanged if no error is thrown.
+
+See [`is_native_instruction`](@ref) for additional information about native instructions.
+
+The transpiler `RejectNonNativeInstructionsTranspiler` takes an `AbstractConnectivity` as
+its first argument and an optional list of `native_gates` (`Vector{DataType}`) as its
+second argument. The gates that are native to the Anyon QPUs are used if `native_gates` is
+not provided.
+
+# Examples
+```jldoctest
+julia> connectivity = LineConnectivity(4)
+LineConnectivity{4}
+1──2──3──4
+
+
+julia> default_transpiler = RejectNonNativeInstructionsTranspiler(connectivity);
+
+
+julia> invalid_circuit = QuantumCircuit(
+           qubit_count = 4,
+           instructions = [sigma_x(4), control_z(1, 3)],
+           )
+Quantum Circuit Object:
+   qubit_count: 4 
+   bit_count: 4 
+q[1]:───────*──
+            |  
+q[2]:───────|──
+            |  
+q[3]:───────Z──
+               
+q[4]:──X───────
+               
+
+julia> transpile(default_transpiler, invalid_circuit)
+ERROR: DomainError with LineConnectivity{4}
+1──2──3──4
+[...]
+
+
+julia> valid_circuit = QuantumCircuit(
+           qubit_count = 4,
+           instructions = [sigma_x(4), control_z(1, 2)],
+           )
+Quantum Circuit Object:
+   qubit_count: 4 
+   bit_count: 4 
+q[1]:───────*──
+            |  
+q[2]:───────Z──
+               
+q[3]:──────────
+               
+q[4]:──X───────
+               
+
+julia> transpiled_circuit = transpile(default_transpiler, valid_circuit)
+Quantum Circuit Object:
+   qubit_count: 4 
+   bit_count: 4 
+q[1]:───────*──
+            |  
+q[2]:───────Z──
+               
+q[3]:──────────
+               
+q[4]:──X───────
+
+
+julia> custom_circuit = QuantumCircuit(
+           qubit_count = 4,
+           instructions = [toffoli(1, 2, 3)],
+           )
+Quantum Circuit Object:
+   qubit_count: 4 
+   bit_count: 4 
+q[1]:──*──
+       |  
+q[2]:──*──
+       |  
+q[3]:──X──
+          
+q[4]:─────
+          
+
+julia> transpile(default_transpiler, custom_circuit)
+ERROR: DomainError with LineConnectivity{4}
+1──2──3──4
+[...]
+
+
+julia> custom_transpiler = RejectNonNativeInstructionsTranspiler(
+            connectivity,
+            [Snowflurry.Toffoli]
+        );
+
+
+julia> transpiled_circuit = transpile(custom_transpiler, custom_circuit)
+Quantum Circuit Object:
+   qubit_count: 4 
+   bit_count: 4 
+q[1]:──*──
+       |  
+q[2]:──*──
+       |  
+q[3]:──X──
+          
+q[4]:─────
+          
+
+```
+"""
 function transpile(
     transpiler::RejectNonNativeInstructionsTranspiler,
     circuit::QuantumCircuit,

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2449,6 +2449,15 @@ end
 
 struct RejectNonNativeInstructionsTranspiler <: Transpiler
     connectivity::AbstractConnectivity
+    native_gates::Vector{DataType}
+
+    function RejectNonNativeInstructionsTranspiler(
+        connectivity::AbstractConnectivity,
+        native_gates::Vector{DataType} = set_of_native_gates,
+    )
+
+        return new(connectivity, native_gates)
+    end
 end
 
 function transpile(
@@ -2456,11 +2465,8 @@ function transpile(
     circuit::QuantumCircuit,
 )::QuantumCircuit
 
-    (passed, message) = is_native_circuit(
-        get_num_qubits(transpiler.connectivity),
-        circuit,
-        transpiler.connectivity,
-    )
+    (passed, message) =
+        is_native_circuit(circuit, transpiler.connectivity, transpiler.native_gates)
 
     if !passed
         throw(DomainError(transpiler.connectivity, message))

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2452,7 +2452,7 @@ struct RejectNonNativeInstructionsTranspiler <: Transpiler
     native_gates::Vector{DataType}
 
     function RejectNonNativeInstructionsTranspiler(
-        connectivity::Union{LineConnectivity,LatticeConnectivity},
+        connectivity::GeometricConnectivity,
         native_gates::Vector{DataType} = set_of_native_gates,
     )
 
@@ -2546,14 +2546,14 @@ q[4]:──X───────
 
 
 julia> custom_circuit = QuantumCircuit(
-           qubit_count = 4,
-           instructions = [toffoli(1, 2, 3)],
-           )
+                  qubit_count = 4,
+                  instructions = [control_x(2, 3)],
+                  )
 Quantum Circuit Object:
    qubit_count: 4 
    bit_count: 4 
-q[1]:──*──
-       |  
+q[1]:─────
+          
 q[2]:──*──
        |  
 q[3]:──X──
@@ -2569,7 +2569,7 @@ ERROR: DomainError with LineConnectivity{4}
 
 julia> custom_transpiler = RejectNonNativeInstructionsTranspiler(
             connectivity,
-            [Snowflurry.Toffoli]
+            [Snowflurry.ControlX]
         );
 
 
@@ -2577,8 +2577,8 @@ julia> transpiled_circuit = transpile(custom_transpiler, custom_circuit)
 Quantum Circuit Object:
    qubit_count: 4 
    bit_count: 4 
-q[1]:──*──
-       |  
+q[1]:─────
+          
 q[2]:──*──
        |  
 q[3]:──X──

--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -2460,8 +2460,8 @@ struct RejectNonNativeInstructionsTranspiler <: Transpiler
     end
 
     function RejectNonNativeInstructionsTranspiler(
-        connectivity::AllToAllConnectivity,
-        native_gates::Vector{DataType} = set_of_native_gates,
+        connectivity::AbstractConnectivity,
+        ::Vector{DataType} = set_of_native_gates,
     )
 
         throw(NotImplementedError(:RejectNonNativeInstructionsTranspiler, connectivity))

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -791,6 +791,11 @@ end
         NonExistentConnectivity(),
     )
 
+    @test_throws NotImplementedError is_native_instruction(
+        sigma_x(1),
+        AllToAllConnectivity(),
+    )
+
     @test_throws NotImplementedError Snowflurry.with_excluded_positions(
         NonExistentConnectivity(),
         Int[],

--- a/test/qpu_interface.jl
+++ b/test/qpu_interface.jl
@@ -783,6 +783,10 @@ end
         NonExistentConnectivity(),
     )
     @test_throws NotImplementedError is_native_instruction(
+        readout(1, 1),
+        NonExistentConnectivity(),
+    )
+    @test_throws NotImplementedError is_native_instruction(
         NonExistentInstruction(),
         LineConnectivity(2),
     )

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -1851,6 +1851,7 @@ end
     @test is_native_instruction(pi_8_dagger(8), connectivity)
     @test is_native_instruction(control_z(5, 6), connectivity)
     @test is_native_instruction(readout(7, 7), connectivity)
+    @test !is_native_instruction(readout(10, 10), connectivity)
     @test !is_native_instruction(toffoli(1, 2, 3), connectivity)
     @test !is_native_instruction(pi_8_dagger(10), connectivity)
     @test !is_native_instruction(control_z(5, 7), connectivity)

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -1835,11 +1835,15 @@ end
     @test_throws DomainError transpile(default_transpiler, circuit)
 
     custom_native_gates = [Snowflurry.Toffoli]
-    custom_transpiler = RejectNonNativeInstructionsTranspiler(
-        connectivity, custom_native_gates
-    )
+    custom_transpiler =
+        RejectNonNativeInstructionsTranspiler(connectivity, custom_native_gates)
 
     @test isequal(transpile(custom_transpiler, circuit), circuit)
+
+    @test_throws(
+        NotImplementedError,
+        RejectNonNativeInstructionsTranspiler(AllToAllConnectivity())
+    )
 end
 
 @testset "is_native_instruction" begin

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -1831,59 +1831,56 @@ end
     end
 end
 
-@testset "is_native_instruction: excluded_positions" begin
+@testset "is_native_instruction" begin
+    connectivity = LineConnectivity(9)
+    @test is_native_instruction(pi_8_dagger(8), connectivity)
+    @test is_native_instruction(control_z(5, 6), connectivity)
+    @test is_native_instruction(readout(7, 7), connectivity)
+    @test !is_native_instruction(toffoli(1, 2, 3), connectivity)
+    @test !is_native_instruction(pi_8_dagger(10), connectivity)
+    @test !is_native_instruction(control_z(5, 7), connectivity)
 
-    excluded_positions = collect(9:12)
+    custom_native_gates = [Snowflurry.Toffoli, Snowflurry.X90]
+    @test is_native_instruction(toffoli(1, 2, 3), connectivity, custom_native_gates)
+    @test !is_native_instruction(toffoli(2, 1, 3), connectivity, custom_native_gates)
+end
 
-    connectivities = [
-        LineConnectivity(20, excluded_positions),
-        LatticeConnectivity(5, 4, excluded_positions),
+@testset "is_native_circuit" begin
+    connectivity = LineConnectivity(20)
+    default_native_instructions = [
+        identity_gate(2),
+        phase_shift(3, 0.2),
+        pi_8(12),
+        pi_8_dagger(11),
+        sigma_x(1),
+        sigma_y(1),
+        sigma_z(2),
+        x_90(1),
+        x_minus_90(1),
+        y_90(1),
+        y_minus_90(1),
+        z_90(1),
+        z_minus_90(1),
+        control_z(19, 20),
+        readout(2, 2),
     ]
 
-    for connectivity in connectivities
-        for target = 1:12
-            input_gates_on_excluded_targets = [
-                phase_shift(target, pi / 3),
-                pi_8(target),
-                pi_8_dagger(target),
-                sigma_x(target),
-                sigma_y(target),
-                sigma_z(target),
-                x_90(target),
-                x_minus_90(target),
-                y_90(target),
-                y_minus_90(target),
-                z_90(target),
-                z_minus_90(target),
-                readout(target, 1),
-            ]
+    default_circuit =
+        QuantumCircuit(qubit_count = 20, instructions = default_native_instructions)
+    @test is_native_circuit(default_circuit, connectivity) == (true, "")
 
-            for instr in input_gates_on_excluded_targets
-                # instr is native iif it targets non-excluded positions
-                @test !is_native_instruction(instr, connectivity) ==
-                      (target in excluded_positions)
-            end
-        end
+    large_circuit = QuantumCircuit(qubit_count = 21)
+    @test is_native_circuit(large_circuit, connectivity) ==
+          (false, "Circuit qubit count 21 exceeds LineConnectivity qubit count: 20")
 
-        for control = 1:20
-            for target = 1:20
-                if target == control
-                    continue
-                end
-
-                instr = control_z(control, target)
-
-                # instr is native if it is connected to adjacent qubits on 
-                # non-excluded positions, and it doesnt reach across the blocked region
-                @test is_native_instruction(instr, connectivity) == (
-                    (get_qubits_distance(target, control, connectivity) == 1) &&
-                    !(target in excluded_positions) &&
-                    !(control in excluded_positions) &&
-                    ((control < 9 && target < 9) || (control > 12 && target > 12))
-                )
-            end
-        end
-    end
+    foreign_circuit = QuantumCircuit(qubit_count = 3, instructions = [toffoli(1, 2, 3)])
+    @test is_native_circuit(foreign_circuit, connectivity) == (
+        false,
+        "Instruction type Gate{Snowflurry.Toffoli} with targets [1, 2, 3] is not native " *
+        "on the connectivity",
+    )
+    @test is_native_circuit(foreign_circuit, connectivity, [Snowflurry.Toffoli]) ==
+          (true, "")
 end
 
 @testset "RejectGatesOnExcludedPositionsTranspiler for all-to-all" begin

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -1802,9 +1802,7 @@ end
 
     connectivities_and_targets = [
         (LineConnectivity(12), (1, 2))
-        (LineConnectivity(12, collect(9:12)), (1, 2))
         (LatticeConnectivity(3, 4), (1, 5))
-        (LatticeConnectivity(3, 4, collect(9:12)), (1, 5))
     ]
 
     for (connectivity, targets) in connectivities_and_targets
@@ -1829,6 +1827,19 @@ end
 
         @test isequal(transpile(transpiler, circuit), circuit)
     end
+
+    connectivity = LineConnectivity(12)
+    default_transpiler = RejectNonNativeInstructionsTranspiler(connectivity)
+    circuit = QuantumCircuit(qubit_count = 6, instructions = [toffoli(1, 2, 3)])
+
+    @test_throws DomainError transpile(default_transpiler, circuit)
+
+    custom_native_gates = [Snowflurry.Toffoli]
+    custom_transpiler = RejectNonNativeInstructionsTranspiler(
+        connectivity, custom_native_gates
+    )
+
+    @test isequal(transpile(custom_transpiler, circuit), circuit)
 end
 
 @testset "is_native_instruction" begin


### PR DESCRIPTION
Removes the check for `excluded_positions` in `RejectNonNativeInstructionsTranspiler`. The option to provide a custom list of native instructions was also added.