### PR TITLE
fix: handle rounding errors for acos

### DIFF
--- a/src/core/transpile.jl
+++ b/src/core/transpile.jl
@@ -92,6 +92,13 @@ end
 
 struct CompressSingleQubitGatesTranspiler <: Transpiler end
 
+function rounding_safe_acos(theta::Real, threshold::Real = 1e-10)
+    if 1.0 < abs(theta) < 1.0 + threshold
+        theta = round(theta)
+    end
+    return acos(theta)
+end
+
 # convert a single-target gate to a Universal gate
 function as_universal_gate(target::Integer, op::AbstractOperator)::Gate{Universal}
     @assert size(op) == (2, 2)
@@ -104,7 +111,7 @@ function as_universal_gate(target::Integer, op::AbstractOperator)::Gate{Universa
     #remove global offset
     matrix *= exp(-im * alpha)
 
-    theta = (2 * acos(real(matrix[1, 1])))
+    theta = (2 * rounding_safe_acos(real(matrix[1, 1])))
 
     if (isapprox(theta, 0.0, atol = 1e-6)) || (isapprox(theta, 2 * π, atol = 1e-6))
         lambda = 0.0

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -75,6 +75,18 @@ test_instructions = [
             get_operator(get_gate_symbol(universal_equivalent)),
         )
     end
+
+    # Operations with rounding errors
+    threshold = 1e-12
+    operator = DenseOperator([
+        1.0+threshold 0.0
+        0.0 1.0
+    ])
+    universal_equivalent = Snowflurry.as_universal_gate(target, operator)
+    @test Snowflurry.compare_operators(
+        operator,
+        get_operator(get_gate_symbol(universal_equivalent)),
+    )
 end
 
 @testset "CompressSingleQubitGatesTranspiler" begin
@@ -149,20 +161,6 @@ end
 
     @test gates[1] isa Snowflurry.Gate{Snowflurry.SigmaX}
     @test gates[2] isa Snowflurry.Gate{Snowflurry.ControlX}
-
-    # circuit with rounding error (acos(1.00...02))
-    circuit = QuantumCircuit(
-        qubit_count = 1,
-        instructions = [
-            rotation_z(1, -0.79715247),
-            rotation_z(1, -0.55272686),
-            rotation_z(1, -1.1681045),
-            readout(1, 1),
-        ],
-    )
-
-    transpiled_circuit = transpile(transpiler, circuit)
-    @test compare_circuits(circuit, transpiled_circuit)
 end
 
 @testset "Transpiler" begin

--- a/test/transpile.jl
+++ b/test/transpile.jl
@@ -149,6 +149,20 @@ end
 
     @test gates[1] isa Snowflurry.Gate{Snowflurry.SigmaX}
     @test gates[2] isa Snowflurry.Gate{Snowflurry.ControlX}
+
+    # circuit with rounding error (acos(1.00...02))
+    circuit = QuantumCircuit(
+        qubit_count = 1,
+        instructions = [
+            rotation_z(1, -0.79715247),
+            rotation_z(1, -0.55272686),
+            rotation_z(1, -1.1681045),
+            readout(1, 1),
+        ],
+    )
+
+    transpiled_circuit = transpile(transpiler, circuit)
+    @test compare_circuits(circuit, transpiled_circuit)
 end
 
 @testset "Transpiler" begin


### PR DESCRIPTION
Rounds values `x` which are slightly greater than 1.0 or less than -1.0 back to 1.0 and -1.0, respectively, before calling `acos(x)`.